### PR TITLE
feat: add manual version input to check-new-version workflow

### DIFF
--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -104,11 +104,13 @@ jobs:
 
       - name: No update needed
         if: steps.tag_check.outputs.exists == 'true'
-        run: echo "Tag v${{ steps.target.outputs.version }} already exists, nothing to do."
+        run: |
+          echo "Tag v${{ steps.target.outputs.version }} already exists, nothing to do."
 
       - name: Already at latest
         if: |
           steps.target.outputs.manual == 'false' &&
           steps.tag_check.outputs.exists == 'false' &&
           steps.target.outputs.version == steps.current.outputs.version
-        run: echo "Already at latest version: ${{ steps.current.outputs.version }}"
+        run: |
+          echo "Already at latest version: ${{ steps.current.outputs.version }}"


### PR DESCRIPTION
## Summary

`workflow_dispatch` にバージョン指定入力を追加。最新以外のバージョンもビルドできるようにする。

## 動作

| 実行方法 | version 入力 | 動作 |
|---------|------------|------|
| スケジュール / 手動 (空) | (なし) | upstream 最新を自動検出、main を更新してタグ push |
| 手動 | `7.1.2-10` など | main を変えず、タグだけ push してビルドをトリガー |

## バージョン指定時の仕組み

```
一時ブランチ "build-7.1.2-10" を作成
  └─ default.json の imagemagick を 7.1.2-10 に書き換えてコミット
  └─ タグ v7.1.2-10 を打って push（ブランチは push しない）
       └─ build.yml がトリガー（タグのコミット時点の default.json を使ってビルド）
```

main ブランチは変更されません。

## 重複防止

タグが既に存在する場合はスキップします（同じバージョンの二重ビルドを防止）。

## Test plan

- [ ] actionlint が通ること
- [ ] 手動で古いバージョン（例: `7.1.2-10`）を指定して実行し、main が変わらずタグだけ作られることを確認
- [ ] 空欄で手動実行し、従来通り最新バージョンが検出・ビルドされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)