### PR TITLE
fix: use GH_PAT in checkout to trigger build workflow on tag push

### DIFF
--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
       - name: Resolve target version
         id: target
@@ -61,14 +62,11 @@ jobs:
         if: |
           steps.target.outputs.manual == 'true' &&
           steps.tag_check.outputs.exists == 'false'
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           NEW="${{ steps.target.outputs.version }}"
           echo "Building specified version: ${NEW}"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}.git"
 
           # 一時ブランチでバージョンを書き換えてタグだけ push（main は変えない）
           git checkout -b "build-${NEW}"
@@ -85,8 +83,6 @@ jobs:
           steps.target.outputs.manual == 'false' &&
           steps.tag_check.outputs.exists == 'false' &&
           steps.target.outputs.version != steps.current.outputs.version
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           NEW="${{ steps.target.outputs.version }}"
           echo "Bumping ImageMagick from ${{ steps.current.outputs.version }} to ${NEW}"
@@ -94,7 +90,6 @@ jobs:
             > versions/default.json.tmp && mv versions/default.json.tmp versions/default.json
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}.git"
           git add versions/default.json
           git commit -m "chore: bump ImageMagick to ${NEW}"
           git tag "v${NEW}"


### PR DESCRIPTION
## 問題

`actions/checkout` はデフォルトで `GITHUB_TOKEN` の credential helper を設定する。
後から `git remote set-url` で PAT を指定しても、credential helper が優先されるため
実際の push は `GITHUB_TOKEN` で認証される。

`GITHUB_TOKEN` での push は他のワークフローをトリガーしない（GitHub の仕様）ため、
タグを push しても `build.yml` が起動しなかった。

## 修正

`actions/checkout` の `token` に `GH_PAT` を渡すことで、checkout 以降の
すべての git 操作（push 含む）が PAT 経由になる。これにより `build.yml` が
正しくトリガーされるようになる。

また、各ステップで不要になった `env: GH_PAT` と `git remote set-url` を削除。

## Test plan

- [ ] actionlint が通ること
- [ ] マージ後、バージョン指定で手動実行し `build.yml` がトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)