### PR TITLE
feat: add Linux ARM64 (aarch64) build support

### DIFF
--- a/.github/actions/build-imagemagick/action.yml
+++ b/.github/actions/build-imagemagick/action.yml
@@ -32,7 +32,6 @@ runs:
           build-essential \
           git \
           cmake \
-          nasm \
           ninja-build \
           autoconf \
           automake \
@@ -42,6 +41,9 @@ runs:
           ghostscript \
           zlib1g-dev \
           ca-certificates
+        if [ "$(uname -m)" = "x86_64" ]; then
+          sudo apt-get install -y --no-install-recommends nasm
+        fi
 
     - name: Read versions
       id: versions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,16 @@ jobs:
         include:
           - runner: ubuntu-22.04
             os_version: 22.04
+            arch: x86_64
           - runner: ubuntu-24.04
             os_version: 24.04
+            arch: x86_64
+          - runner: ubuntu-22.04-arm
+            os_version: 22.04
+            arch: aarch64
+          - runner: ubuntu-24.04-arm
+            os_version: 24.04
+            arch: aarch64
 
     steps:
       - name: Checkout
@@ -46,6 +54,7 @@ jobs:
           mkdir -p /tmp/artifacts
           sudo VERSION_FILE="${{ steps.build.outputs.version_file }}" \
                UBUNTU_VERSION=${{ matrix.os_version }} \
+               ARCH=${{ matrix.arch }} \
                PREFIX=/opt/imagemagick \
                ARCHIVE_DIR=/tmp/artifacts \
                bash scripts/package.sh
@@ -54,7 +63,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: imagemagick-${{ steps.build.outputs.imagemagick }}-ubuntu${{ matrix.os_version }}-x86_64
+          name: imagemagick-${{ steps.build.outputs.imagemagick }}-ubuntu${{ matrix.os_version }}-${{ matrix.arch }}
           path: /tmp/artifacts/*.tar.gz
           retention-days: 7
 
@@ -86,7 +95,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: imagemagick-${{ steps.versions.outputs.imagemagick }}-ubuntu*-x86_64
+          pattern: imagemagick-${{ steps.versions.outputs.imagemagick }}-ubuntu*
           merge-multiple: true
           path: /tmp/artifacts/
 
@@ -96,7 +105,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ImageMagick ${{ steps.versions.outputs.imagemagick }}
           body: |
-            ## ImageMagick ${{ steps.versions.outputs.imagemagick }} — Ubuntu 22.04 / 24.04 x86_64
+            ## ImageMagick ${{ steps.versions.outputs.imagemagick }} — Ubuntu 22.04 / 24.04 · x86_64 / aarch64
 
             Pre-built ImageMagick binary with SDK for RMagick / CI use.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         include:
           - runner: ubuntu-22.04
           - runner: ubuntu-24.04
+          - runner: ubuntu-22.04-arm
+          - runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -9,8 +9,9 @@ VERSION_FILE="${VERSION_FILE:-${REPO_ROOT}/versions/default.json}"
 PREFIX="${PREFIX:-/opt/imagemagick}"
 IM_VERSION=$(jq -r '.imagemagick' "${VERSION_FILE}")
 UBUNTU_VERSION="${UBUNTU_VERSION:-22.04}"
+ARCH="${ARCH:-$(uname -m)}"
 
-ARCHIVE_NAME="imagemagick-${IM_VERSION}-ubuntu${UBUNTU_VERSION}-x86_64.tar.gz"
+ARCHIVE_NAME="imagemagick-${IM_VERSION}-ubuntu${UBUNTU_VERSION}-${ARCH}.tar.gz"
 ARCHIVE_PATH="${ARCHIVE_DIR:-/tmp}/${ARCHIVE_NAME}"
 
 echo "=== Packaging ImageMagick ${IM_VERSION} ==="


### PR DESCRIPTION
## Summary

- `ubuntu-22.04-arm` / `ubuntu-24.04-arm` ランナーを `build.yml` と `ci.yml` のマトリックスに追加
- `nasm` (x86専用アセンブラ) のインストールを x86_64 のみに条件分岐
- `scripts/package.sh` のアーキテクチャをハードコードの `x86_64` から動的な `ARCH` 変数に変更
- アーティファクト名・リリースのダウンロードパターンを両アーキテクチャ対応に更新

Closes #18

## Test plan

- [ ] PR で CI が 4 ジョブ (22.04/24.04 × x86_64/aarch64) すべて通ることを確認
- [ ] `v*` タグ push 時に 4 つの tarball がリリースに添付されることを確認
- [ ] tarball 名に正しいアーキテクチャサフィックス (`x86_64` / `aarch64`) が付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)