### PR TITLE
fix: use git-tags datasource for libaom (hosted on googlesource)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "enabledManagers": ["github-actions", "custom.regex"],
-  "ignoreDeps": ["imagemagick", "libaom"],
+  "ignoreDeps": ["imagemagick"],
   "customManagers": [
     {
       "customType": "regex",
@@ -46,6 +46,15 @@
       "matchStrings": ["\"libwebp\":\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "webmproject/libwebp",
       "datasourceTemplate": "github-releases",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^versions/default\\.json$"],
+      "matchStrings": ["\"libaom\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "https://aomedia.googlesource.com/aom",
+      "datasourceTemplate": "git-tags",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^v?(?<version>.+)$"
     },


### PR DESCRIPTION
## Summary

- Renovate が `AOMediaCodec/libaom` を GitHub で見つけられずエラーになっていた
- libaom は `aomedia.googlesource.com` でホストされているため `github-releases` では参照不可
- `git-tags` datasource に変更し、googlesource のタグを直接追跡するよう修正

## Before / After

| | Before | After |
|---|---|---|
| datasource | `github-releases` | `git-tags` |
| depName | `AOMediaCodec/libaom` | `https://aomedia.googlesource.com/aom` |

## Related

Closes #21 (Renovate warning: Failed to look up github-releases package AOMediaCodec/libaom)