### PR TITLE
feat: rebuild on bundled library update with dated snapshot tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,18 @@ jobs:
             echo "libheif=$(jq -r '.libheif' versions/default.json)"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Detect tag type
+        id: tag_type
+        run: |
+          TAG="${{ github.ref_name }}"
+          IM_VERSION="${{ steps.versions.outputs.imagemagick }}"
+          # Dated snapshot tags look like v7.1.2-18-20260405 or v7.1.2-18-20260405-2
+          if [[ "${TAG}" == "v${IM_VERSION}-"* ]]; then
+            echo "is_dated=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "is_dated=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -99,41 +111,62 @@ jobs:
           merge-multiple: true
           path: /tmp/artifacts/
 
+      - name: Generate release body
+        run: |
+          IM_VERSION="${{ steps.versions.outputs.imagemagick }}"
+          cat > /tmp/release_body.md << BODYEOF
+          ## ImageMagick ${IM_VERSION} — Ubuntu 22.04 / 24.04 · x86_64 / aarch64
+
+          Pre-built ImageMagick binary with SDK for RMagick / CI use.
+
+          ### Included libraries
+
+          | Library | Version |
+          |---------|---------|
+          | ImageMagick | ${IM_VERSION} |
+          | libjpeg-turbo | ${{ steps.versions.outputs.libjpeg_turbo }} |
+          | libpng | ${{ steps.versions.outputs.libpng }} |
+          | libtiff | ${{ steps.versions.outputs.libtiff }} |
+          | lcms2 | ${{ steps.versions.outputs.lcms2 }} |
+          | libwebp | ${{ steps.versions.outputs.libwebp }} |
+          | libaom | ${{ steps.versions.outputs.libaom }} |
+          | libheif | ${{ steps.versions.outputs.libheif }} |
+
+          ### Supported formats
+
+          JPEG · PNG · TIFF · WebP · AVIF · PDF
+
+          ### Install
+
+          \`\`\`bash
+          tar -xzf imagemagick-*.tar.gz -C /opt
+          export PATH="/opt/imagemagick/${IM_VERSION}/bin:\$PATH"
+          export PKG_CONFIG_PATH="/opt/imagemagick/${IM_VERSION}/lib/pkgconfig:\$PKG_CONFIG_PATH"
+          export LD_LIBRARY_PATH="/opt/imagemagick/${IM_VERSION}/lib:\$LD_LIBRARY_PATH"
+          \`\`\`
+          BODYEOF
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ImageMagick ${{ steps.versions.outputs.imagemagick }}
-          body: |
-            ## ImageMagick ${{ steps.versions.outputs.imagemagick }} — Ubuntu 22.04 / 24.04 · x86_64 / aarch64
-
-            Pre-built ImageMagick binary with SDK for RMagick / CI use.
-
-            ### Included libraries
-
-            | Library | Version |
-            |---------|---------|
-            | ImageMagick | ${{ steps.versions.outputs.imagemagick }} |
-            | libjpeg-turbo | ${{ steps.versions.outputs.libjpeg_turbo }} |
-            | libpng | ${{ steps.versions.outputs.libpng }} |
-            | libtiff | ${{ steps.versions.outputs.libtiff }} |
-            | lcms2 | ${{ steps.versions.outputs.lcms2 }} |
-            | libwebp | ${{ steps.versions.outputs.libwebp }} |
-            | libaom | ${{ steps.versions.outputs.libaom }} |
-            | libheif | ${{ steps.versions.outputs.libheif }} |
-
-            ### Supported formats
-
-            JPEG · PNG · TIFF · WebP · AVIF · PDF
-
-            ### Install
-
-            ```bash
-            tar -xzf imagemagick-*.tar.gz -C /opt
-            export PATH="/opt/imagemagick/${{ steps.versions.outputs.imagemagick }}/bin:$PATH"
-            export PKG_CONFIG_PATH="/opt/imagemagick/${{ steps.versions.outputs.imagemagick }}/lib/pkgconfig:$PKG_CONFIG_PATH"
-            export LD_LIBRARY_PATH="/opt/imagemagick/${{ steps.versions.outputs.imagemagick }}/lib:$LD_LIBRARY_PATH"
-            ```
+          body_path: /tmp/release_body.md
           files: /tmp/artifacts/*.tar.gz
           draft: false
           prerelease: false
+
+      - name: Update rolling release
+        if: steps.tag_type.outputs.is_dated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ROLLING_TAG="v${{ steps.versions.outputs.imagemagick }}"
+
+          # Upload new artifacts, overwriting existing ones (-clobber replaces files with same name)
+          gh release upload "${ROLLING_TAG}" /tmp/artifacts/*.tar.gz --clobber
+
+          # Update release title and body
+          gh release edit "${ROLLING_TAG}" \
+            --title "ImageMagick ${{ steps.versions.outputs.imagemagick }}" \
+            --notes-file /tmp/release_body.md

--- a/.github/workflows/rebuild-on-library-update.yml
+++ b/.github/workflows/rebuild-on-library-update.yml
@@ -1,0 +1,67 @@
+name: Rebuild on library update
+
+on:
+  push:
+    branches: [main]
+    paths: ['versions/default.json']
+
+permissions:
+  contents: write
+
+jobs:
+  create-snapshot-tag:
+    name: Create snapshot tag for library rebuild
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Check if this is a library-only update
+        id: check
+        run: |
+          IM_VERSION=$(jq -r '.imagemagick' versions/default.json)
+          echo "im_version=${IM_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          # If the imagemagick version itself changed, this is an IM bump committed by
+          # check-new-version.yml — that workflow already handles tag creation, so skip here.
+          PREV_IM=$(git show HEAD~1:versions/default.json 2>/dev/null \
+            | jq -r '.imagemagick' 2>/dev/null || echo "")
+          if [ "${PREV_IM}" != "${IM_VERSION}" ]; then
+            echo "is_library_update=false" >> "${GITHUB_OUTPUT}"
+            echo "ImageMagick version changed (${PREV_IM} → ${IM_VERSION}) — check-new-version.yml handles this"
+            exit 0
+          fi
+
+          # IM version is unchanged. If v{IM_VERSION} tag already exists,
+          # this is a library-only rebuild.
+          if git ls-remote --tags origin "refs/tags/v${IM_VERSION}" | grep -q .; then
+            echo "is_library_update=true" >> "${GITHUB_OUTPUT}"
+            echo "Library-only update detected for IM ${IM_VERSION}"
+          else
+            echo "is_library_update=false" >> "${GITHUB_OUTPUT}"
+            echo "Tag v${IM_VERSION} does not exist yet — skipping"
+          fi
+
+      - name: Create snapshot tag
+        if: steps.check.outputs.is_library_update == 'true'
+        run: |
+          IM_VERSION="${{ steps.check.outputs.im_version }}"
+          DATE=$(date +%Y%m%d)
+          TAG="v${IM_VERSION}-${DATE}"
+
+          # Handle same-day collisions by appending a counter
+          BASE_TAG="${TAG}"
+          N=1
+          while git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; do
+            N=$((N + 1))
+            TAG="${BASE_TAG}-${N}"
+          done
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${TAG}"
+          git push origin "${TAG}"
+          echo "Created snapshot tag: ${TAG}"

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ## Overview
 
-This repository builds [ImageMagick](https://imagemagick.org/) from source with all required libraries statically bundled, and publishes pre-built tarballs for Ubuntu 22.04 and 24.04 (x86\_64) as GitHub Releases. New ImageMagick versions are detected automatically every week and released without manual intervention.
+This repository builds [ImageMagick](https://imagemagick.org/) from source with all required libraries statically bundled, and publishes pre-built tarballs for Ubuntu 22.04 and 24.04 (x86\_64 and aarch64) as GitHub Releases. New ImageMagick versions are detected automatically every week, and bundled library updates are also rebuilt automatically via Renovate.
 
 ---
 
-このリポジトリは [ImageMagick](https://imagemagick.org/) を必要なライブラリごとソースからビルドし、Ubuntu 22.04 / 24.04 (x86\_64) 向けの事前ビルド済みアーカイブを GitHub Releases として公開します。新しい ImageMagick バージョンは毎週自動的に検出され、手動操作なしにリリースされます。
+このリポジトリは [ImageMagick](https://imagemagick.org/) を必要なライブラリごとソースからビルドし、Ubuntu 22.04 / 24.04 (x86\_64 / aarch64) 向けの事前ビルド済みアーカイブを GitHub Releases として公開します。新しい ImageMagick バージョンは毎週自動的に検出され、同梱ライブラリの更新も Renovate により自動的にリビルドされます。
 
 ## Supported Formats / 対応フォーマット
 
@@ -19,7 +19,7 @@ JPEG, PNG, TIFF, WebP, AVIF, PDF
 
 | Library | Version |
 |---|---|
-| ImageMagick | 7.1.2-13 |
+| ImageMagick | 7.1.2-18 |
 | libjpeg-turbo | 3.0.3 |
 | libpng | 1.6.43 |
 | libtiff | 4.7.0 |
@@ -40,11 +40,11 @@ Download the tarball for your Ubuntu version from the [Releases page](https://gi
 
 ```bash
 # Example for Ubuntu 22.04
-tar -xzf imagemagick-7.1.2-13-ubuntu22.04-x86_64.tar.gz -C /opt
+tar -xzf imagemagick-7.1.2-18-ubuntu22.04-x86_64.tar.gz -C /opt
 
-export PATH="/opt/imagemagick/7.1.2-13/bin:$PATH"
-export PKG_CONFIG_PATH="/opt/imagemagick/7.1.2-13/lib/pkgconfig:$PKG_CONFIG_PATH"
-export LD_LIBRARY_PATH="/opt/imagemagick/7.1.2-13/lib:$LD_LIBRARY_PATH"
+export PATH="/opt/imagemagick/7.1.2-18/bin:$PATH"
+export PKG_CONFIG_PATH="/opt/imagemagick/7.1.2-18/lib/pkgconfig:$PKG_CONFIG_PATH"
+export LD_LIBRARY_PATH="/opt/imagemagick/7.1.2-18/lib:$LD_LIBRARY_PATH"
 
 magick -version
 ```
@@ -55,11 +55,11 @@ magick -version
 
 ```bash
 # Ubuntu 22.04 の例
-tar -xzf imagemagick-7.1.2-13-ubuntu22.04-x86_64.tar.gz -C /opt
+tar -xzf imagemagick-7.1.2-18-ubuntu22.04-x86_64.tar.gz -C /opt
 
-export PATH="/opt/imagemagick/7.1.2-13/bin:$PATH"
-export PKG_CONFIG_PATH="/opt/imagemagick/7.1.2-13/lib/pkgconfig:$PKG_CONFIG_PATH"
-export LD_LIBRARY_PATH="/opt/imagemagick/7.1.2-13/lib:$LD_LIBRARY_PATH"
+export PATH="/opt/imagemagick/7.1.2-18/bin:$PATH"
+export PKG_CONFIG_PATH="/opt/imagemagick/7.1.2-18/lib/pkgconfig:$PKG_CONFIG_PATH"
+export LD_LIBRARY_PATH="/opt/imagemagick/7.1.2-18/lib:$LD_LIBRARY_PATH"
 
 magick -version
 ```
@@ -106,18 +106,42 @@ The output tarball will be at `/tmp/artifacts/imagemagick-<version>-ubuntu22.04-
 
 | Workflow | Trigger | Description |
 |---|---|---|
-| [`build.yml`](.github/workflows/build.yml) | Push to `main`, tag push, manual | Builds for Ubuntu 22.04 & 24.04, creates GitHub Release on tag push |
+| [`build.yml`](.github/workflows/build.yml) | Tag push (`v*`), manual | Builds for Ubuntu 22.04 & 24.04 (x86\_64 / aarch64), creates GitHub Release on tag push |
 | [`check-new-version.yml`](.github/workflows/check-new-version.yml) | Weekly (Mon 09:00 UTC), manual | Detects latest ImageMagick release, bumps `versions/default.json`, pushes a new tag |
+| [`rebuild-on-library-update.yml`](.github/workflows/rebuild-on-library-update.yml) | Push to `main` (when `versions/default.json` changes) | Detects library-only updates, creates a dated snapshot tag to trigger a rebuild |
 | [`ci.yml`](.github/workflows/ci.yml) | Pull request to `main` | Lints workflows with actionlint and runs a test build |
 
-The typical automated flow:
+### Release naming / リリースのタグ命名
 
+| Tag | Description |
+|---|---|
+| `vX.Y.Z-N` | Rolling release — always points to the latest build for that ImageMagick version |
+| `vX.Y.Z-N-YYYYMMDD` | Snapshot release — a pinned build created when bundled libraries are updated |
+
+The typical automated flows:
+
+**New ImageMagick version:**
 1. `check-new-version.yml` detects a new upstream release → updates `versions/default.json` → pushes tag `vX.Y.Z-N`
-2. The tag push triggers `build.yml` → compiles on both Ubuntu versions → publishes a GitHub Release with the tarballs attached
+2. The tag push triggers `build.yml` → compiles on all 4 platforms → publishes a GitHub Release
+
+**Bundled library update (Renovate):**
+1. Renovate merges a PR updating library versions in `versions/default.json`
+2. `rebuild-on-library-update.yml` creates a dated snapshot tag `vX.Y.Z-N-YYYYMMDD`
+3. The tag push triggers `build.yml` → compiles on all 4 platforms
+4. The snapshot release `vX.Y.Z-N-YYYYMMDD` is published, and the rolling release `vX.Y.Z-N` is updated with the new artifacts
 
 ---
 
+### ワークフローの説明
+
 自動化の典型的なフローは以下の通りです。
 
+**新しい ImageMagick バージョン:**
 1. `check-new-version.yml` が新しいアップストリームリリースを検出 → `versions/default.json` を更新 → タグ `vX.Y.Z-N` をプッシュ
-2. タグのプッシュにより `build.yml` がトリガー → 両 Ubuntu バージョンでコンパイル → アーカイブ付きで GitHub Release を公開
+2. タグのプッシュにより `build.yml` がトリガー → 4プラットフォームでコンパイル → アーカイブ付きで GitHub Release を公開
+
+**同梱ライブラリの更新（Renovate）:**
+1. Renovate が `versions/default.json` のライブラリバージョンを更新する PR をマージ
+2. `rebuild-on-library-update.yml` が日付付きスナップショットタグ `vX.Y.Z-N-YYYYMMDD` を作成
+3. タグのプッシュにより `build.yml` がトリガー → 4プラットフォームでコンパイル
+4. スナップショットリリース `vX.Y.Z-N-YYYYMMDD` が公開され、ローリングリリース `vX.Y.Z-N` の成果物も更新される


### PR DESCRIPTION
## Summary

- Add `rebuild-on-library-update.yml` workflow that detects library-only updates to `versions/default.json` and creates a dated snapshot tag (`vX.Y.Z-N-YYYYMMDD`) to trigger a rebuild
- Update `build.yml` release job to create a snapshot release for dated tags and update the rolling release (`vX.Y.Z-N`) with new artifacts
- Update `README.md` to document aarch64 support, new workflow, and release naming scheme

## Release naming

| Tag | Description |
|---|---|
| `vX.Y.Z-N` | Rolling release — always latest build for that ImageMagick version |
| `vX.Y.Z-N-YYYYMMDD` | Snapshot release — pinned build created when bundled libraries are updated |

## Flow (library update via Renovate)

1. Renovate merges a PR updating `versions/default.json`
2. `rebuild-on-library-update.yml` creates `vX.Y.Z-N-YYYYMMDD` snapshot tag
3. `build.yml` triggers → builds on all 4 platforms
4. Snapshot release published + rolling release updated with new artifacts

## Test plan

- [ ] Merge a library-version change to `main` and confirm `rebuild-on-library-update.yml` creates a dated tag
- [ ] Confirm `build.yml` runs and produces both `vX.Y.Z-N-YYYYMMDD` and updated `vX.Y.Z-N` releases
- [ ] Confirm `check-new-version.yml` is not affected when it bumps ImageMagick version

🤖 Generated with [Claude Code](https://claude.com/claude-code)