### PR TITLE
feat: re-enable AL2023 installer test

### DIFF
--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -31,7 +31,22 @@ jobs:
           - runner: ubuntu-24.04-arm
             os_tag: ubuntu24.04
             arch: aarch64
+          - runner: ubuntu-24.04
+            container: amazonlinux:2023
+            os_tag: amzn2023
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            container: amazonlinux:2023
+            os_tag: amzn2023
+            arch: aarch64
+
+    container: ${{ matrix.container || '' }}
+
     steps:
+      - name: Install tar, git, and curl (AL2023 minimal container)
+        if: matrix.os_tag == 'amzn2023'
+        run: dnf install -y tar git curl
+
       - name: Checkout
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- AL2023 binaries が v7.1.2-18-20260405-3 リリースで公開されたため、`test-installer.yml` に AL2023 のインストーラーテストを追加

## Test plan

- [x] `Test install.sh (amzn2023-x86_64)` が通過すること
- [x] `Test install.sh (amzn2023-aarch64)` が通過すること
- [x] Ubuntu の既存テストが引き続き通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)