### PR TITLE
feat: add CycloneDX SBOM to release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,11 +85,21 @@ jobs:
                bash scripts/package.sh
           ls -lh /tmp/artifacts/
 
+      - name: Generate SBOM
+        run: |
+          for tarball in /tmp/artifacts/*.tar.gz; do
+            sbom="${tarball%.tar.gz}.sbom.json"
+            VERSION_FILE="${{ steps.build.outputs.version_file }}" \
+              OS_TAG=${{ matrix.os_tag }} \
+              ARCH=${{ matrix.arch }} \
+              bash scripts/generate-sbom.sh "$sbom"
+          done
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: imagemagick-${{ steps.build.outputs.imagemagick }}-${{ matrix.os_tag }}-${{ matrix.arch }}
-          path: /tmp/artifacts/*.tar.gz
+          path: /tmp/artifacts/
           retention-days: 7
 
   release:
@@ -180,7 +190,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ImageMagick ${{ steps.versions.outputs.imagemagick }}
           body_path: /tmp/release_body.md
-          files: /tmp/artifacts/*.tar.gz
+          files: /tmp/artifacts/*
           draft: false
           prerelease: false
 
@@ -192,7 +202,7 @@ jobs:
           ROLLING_TAG="v${{ steps.versions.outputs.imagemagick }}"
 
           # Upload new artifacts, overwriting existing ones (-clobber replaces files with same name)
-          gh release upload "${ROLLING_TAG}" /tmp/artifacts/*.tar.gz --clobber
+          gh release upload "${ROLLING_TAG}" /tmp/artifacts/* --clobber
 
           # Update release title and body
           gh release edit "${ROLLING_TAG}" \

--- a/install.sh
+++ b/install.sh
@@ -79,8 +79,14 @@ fi
 unset _curl_auth
 ASSET_URL=$(echo "$RELEASE_JSON" \
   | grep '"browser_download_url"' \
-  | grep "${OS_TAG}-${ARCH}" \
-  | cut -d'"' -f4)
+  | cut -d'"' -f4 \
+  | grep -E "${OS_TAG}-${ARCH}\.tar\.gz$")
+
+if [[ "$(echo "$ASSET_URL" | wc -l)" -gt 1 ]]; then
+  echo "Error: Multiple matching tarball assets found for ${OS_TAG} ${ARCH}" >&2
+  echo "$ASSET_URL" >&2
+  exit 1
+fi
 
 if [[ -z "$ASSET_URL" ]]; then
   echo "Error: No matching asset found for ${OS_TAG} ${ARCH}" >&2

--- a/scripts/generate-sbom.sh
+++ b/scripts/generate-sbom.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Generate a CycloneDX 1.4 JSON SBOM from versions/default.json.
+#
+# Usage:
+#   VERSION_FILE=<path> OS_TAG=<os> ARCH=<arch> bash scripts/generate-sbom.sh <output.sbom.json>
+#
+# Bundled libraries (compiled from source, included in tarball):
+#   ImageMagick, libjpeg-turbo, libpng, libtiff, lcms2, libwebp, libaom, libheif
+#
+# System runtime dependencies (NOT bundled, scope=optional):
+#   ghostscript (PDF support), freetype, zlib
+set -euo pipefail
+
+OUTPUT="${1:?Usage: VERSION_FILE=<path> OS_TAG=<os> ARCH=<arch> $0 <output.sbom.json>}"
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+jq -n \
+  --arg ts        "$TIMESTAMP" \
+  --arg name      "imagemagick-$(jq -r '.imagemagick' "$VERSION_FILE")-${OS_TAG}-${ARCH}" \
+  --argjson v     "$(cat "$VERSION_FILE")" \
+  '{
+    bomFormat:   "CycloneDX",
+    specVersion: "1.4",
+    version:     1,
+    metadata: {
+      timestamp: $ts,
+      component: {
+        type:    "application",
+        name:    $name,
+        version: $v.imagemagick
+      }
+    },
+    components: [
+      {
+        type:    "library",
+        name:    "ImageMagick",
+        version: $v.imagemagick,
+        purl:    ("pkg:github/ImageMagick/ImageMagick@" + $v.imagemagick)
+      },
+      {
+        type:    "library",
+        name:    "libjpeg-turbo",
+        version: $v.libjpeg_turbo,
+        purl:    ("pkg:github/libjpeg-turbo/libjpeg-turbo@" + $v.libjpeg_turbo)
+      },
+      {
+        type:    "library",
+        name:    "libpng",
+        version: $v.libpng,
+        purl:    ("pkg:github/glennrp/libpng@" + $v.libpng)
+      },
+      {
+        type:    "library",
+        name:    "libtiff",
+        version: $v.libtiff,
+        purl:    ("pkg:gitlab/libtiff/libtiff@" + $v.libtiff)
+      },
+      {
+        type:    "library",
+        name:    "lcms2",
+        version: $v.lcms2,
+        purl:    ("pkg:github/mm2/Little-CMS@" + $v.lcms2)
+      },
+      {
+        type:    "library",
+        name:    "libwebp",
+        version: $v.libwebp,
+        purl:    ("pkg:github/webmproject/libwebp@" + $v.libwebp)
+      },
+      {
+        type:    "library",
+        name:    "libaom",
+        version: $v.libaom,
+        purl:    ("pkg:github/AOMediaCodec/libaom@" + $v.libaom)
+      },
+      {
+        type:    "library",
+        name:    "libheif",
+        version: $v.libheif,
+        purl:    ("pkg:github/strukturag/libheif@" + $v.libheif)
+      },
+      {
+        type:        "library",
+        name:        "ghostscript",
+        scope:       "optional",
+        description: "System-provided runtime dependency for PDF support. Not bundled in the tarball; version depends on the host OS."
+      },
+      {
+        type:        "library",
+        name:        "freetype",
+        scope:       "optional",
+        description: "System-provided runtime dependency. Not bundled in the tarball."
+      },
+      {
+        type:        "library",
+        name:        "zlib",
+        scope:       "optional",
+        description: "System-provided runtime dependency. Not bundled in the tarball."
+      }
+    ]
+  }' > "$OUTPUT"


### PR DESCRIPTION
## Summary

- `scripts/generate-sbom.sh` を新規作成 — `versions/default.json` から CycloneDX 1.4 JSON SBOM を生成
- build ジョブに "Generate SBOM" ステップを追加（パッケージ後、アップロード前）
- アーティファクトアップロード・リリース・ローリングリリースを `.sbom.json` を含むよう修正

**SBOM の内訳**
- バンドル済みライブラリ（ソースビルド・tarball 同梱）: ImageMagick, libjpeg-turbo, libpng, libtiff, lcms2, libwebp, libaom, libheif → バージョン・purl 付きで記載
- システムランタイム依存（tarball 非同梱）: ghostscript（PDF）, freetype, zlib → `scope: "optional"` でバージョン省略

**完了後のリリース資産**
```
imagemagick-7.x.x-ubuntu22.04-x86_64.tar.gz
imagemagick-7.x.x-ubuntu22.04-x86_64.sbom.json  ← 追加
... (6プラットフォーム × 2ファイル)
```

## Test plan

- [ ] タグをプッシュして、リリース資産に各プラットフォームの `.sbom.json` が添付されることを確認
- [ ] `jq .bomFormat imagemagick-*.sbom.json` → `"CycloneDX"` を確認
- [ ] ローリングリリース（`v{IM_VERSION}`）にも SBOM が上書きアップロードされることを確認
- [ ] （任意）`grype sbom:imagemagick-*.sbom.json` で脆弱性スキャナーがパースできることを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)