### PR TITLE
fix: bump cache key v2→v3 to fix AL2023 JPEG missing

### DIFF
--- a/.github/actions/build-imagemagick/action.yml
+++ b/.github/actions/build-imagemagick/action.yml
@@ -105,7 +105,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: /opt/imagemagick
-        key: v2-imagemagick-libs-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache_suffix }}-${{ steps.version-hash.outputs.hash }}
+        key: v3-imagemagick-libs-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache_suffix }}-${{ steps.version-hash.outputs.hash }}
 
     - name: Build all libraries and ImageMagick
       if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## 問題

AL2023のCIジョブで `[MISSING] JPEG` が発生していた。

`magick -version` では `jpeg` がデリゲートに表示されるにもかかわらず、`verify.sh` のフォーマットチェックで失敗する。

## 原因

キャッシュキーが `versions/default.json` のハッシュのみで決まるため、コミット `2f9ecfa`（`-DCMAKE_INSTALL_LIBDIR=lib` の修正）より前に保存された古いキャッシュが使い回されていた。

その古いキャッシュでは libjpeg-turbo が RHEL系CMakeのデフォルト動作により `/opt/imagemagick/lib64/` にインストールされている。一方 `verify.sh` は `LD_LIBRARY_PATH="${PREFIX}/lib"` のみ設定するため、実行時に `libjpeg.so` が見つからず JPEG が `[MISSING]` になる。

## 修正

キャッシュキーのバージョンプレフィックスを `v2-` → `v3-` に変更。

次回CI実行時にキャッシュミスが発生し、`-DCMAKE_INSTALL_LIBDIR=lib` 付きの修正済みビルドスクリプトで再ビルドされる。

## 確認事項

- [x] AL2023 x86_64 で `[OK] JPEG` が表示されること
- [x] AL2023 aarch64 で `[OK] JPEG` が表示されること
- [ ] Ubuntu 22.04/24.04 は引き続き正常に動作すること（新しいキャッシュキーで再ビルド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)