### PR TITLE
fix: use github.ref_name instead of undefined ${TAG} in release body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
           ### Install
 
           \`\`\`bash
-          curl -fsSL https://raw.githubusercontent.com/jksy/imagemagick-build/main/install.sh | IMAGEMAGICK_VERSION=${TAG} bash
+          curl -fsSL https://raw.githubusercontent.com/jksy/imagemagick-build/main/install.sh | IMAGEMAGICK_VERSION=${{ github.ref_name }} bash
           \`\`\`
 
           最新版をインストールする場合 / To install the latest version:


### PR DESCRIPTION
## Summary

- リリースノートの Install セクションで `IMAGEMAGICK_VERSION=` の後が空になる問題を修正
- `${TAG}` は「Generate release body」ステップのシェルスコープで未定義だったため、`${{ github.ref_name }}` に変更

## Test plan

- [ ] 次のリリース後、リリースページの Install セクションに `IMAGEMAGICK_VERSION=v7.1.2-18-...` が正しく入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)