### PR TITLE
fix: include scripts/ hash in cache key to auto-invalidate on script changes

### DIFF
--- a/.github/actions/build-imagemagick/action.yml
+++ b/.github/actions/build-imagemagick/action.yml
@@ -99,10 +99,13 @@ runs:
           mkdir -p /opt/imagemagick
         fi
 
-    - name: Compute version file hash
+    - name: Compute cache key inputs
       id: version-hash
       shell: bash
-      run: echo "hash=$(sha256sum '${{ inputs.version_file }}' | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
+      run: |
+        versions_hash=$(sha256sum '${{ inputs.version_file }}' | cut -d' ' -f1)
+        scripts_hash=$(find scripts/ -name '*.sh' | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+        echo "hash=${versions_hash}-${scripts_hash}" >> "${GITHUB_OUTPUT}"
 
     - name: Restore library cache
       id: cache


### PR DESCRIPTION
## Summary

- `Compute version file hash` ステップを `Compute cache key inputs` にリネームし、ロジックを拡張
- `scripts/*.sh` 全ファイルの結合ハッシュをキャッシュキーに追加
- これにより `scripts/build.sh` 等を変更した際に手動でキャッシュキーのバージョンプレフィックスを変更しなくてもキャッシュが自動無効化される

Closes #35

## Test plan

- [x] `scripts/build.sh` に小さな変更を加えてプッシュ → CI でキャッシュミスが発生しフルビルドが走ることを確認
- [x] 変更なしで再実行 → キャッシュヒットすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)