### PR TITLE
feat: add SLSA Level 3 provenance attestation for release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # OIDC token for SLSA provenance generator
+  actions: read    # Required by slsa-github-generator
 
 jobs:
   build:
@@ -101,6 +103,40 @@ jobs:
           name: imagemagick-${{ steps.build.outputs.imagemagick }}-${{ matrix.os_tag }}-${{ matrix.arch }}
           path: /tmp/artifacts/
           retention-days: 7
+
+      - name: Compute SHA256
+        run: |
+          cd /tmp/artifacts
+          sha256sum *.tar.gz > /tmp/sha256sums.txt
+          cat /tmp/sha256sums.txt
+
+      - name: Upload SHA256
+        uses: actions/upload-artifact@v7
+        with:
+          name: sha256-${{ matrix.os_tag }}-${{ matrix.arch }}
+          path: /tmp/sha256sums.txt
+          retention-days: 7
+
+  aggregate-hashes:
+    name: Aggregate SHA256 hashes
+    needs: build
+    runs-on: ubuntu-24.04
+    if: startsWith(github.ref, 'refs/tags/v')
+    outputs:
+      base64-subjects: ${{ steps.aggregate.outputs.base64-subjects }}
+    steps:
+      - name: Download all SHA256 files
+        uses: actions/download-artifact@v8
+        with:
+          pattern: sha256-*
+          merge-multiple: true
+          path: /tmp/sha256sums/
+
+      - name: Aggregate and base64-encode
+        id: aggregate
+        run: |
+          cat /tmp/sha256sums/*.txt > /tmp/all-sha256sums.txt
+          echo "base64-subjects=$(base64 -w0 < /tmp/all-sha256sums.txt)" >> "${GITHUB_OUTPUT}"
 
   release:
     name: Create GitHub Release
@@ -211,3 +247,16 @@ jobs:
           gh release edit "${ROLLING_TAG}" \
             --title "ImageMagick ${{ steps.versions.outputs.imagemagick }}" \
             --notes-file /tmp/release_body.md
+
+  provenance:
+    name: Generate SLSA Provenance
+    needs: [release, aggregate-hashes]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563
+    with:
+      base64-subjects: "${{ needs.aggregate-hashes.outputs.base64-subjects }}"
+      upload-assets: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Compute SHA256
         run: |
           cd /tmp/artifacts
-          sha256sum *.tar.gz > /tmp/sha256sums.txt
+          sha256sum ./*.tar.gz > /tmp/sha256sums.txt
           cat /tmp/sha256sums.txt
 
       - name: Upload SHA256


### PR DESCRIPTION
## Summary

- タグプッシュ時に `slsa-github-generator` を使って SLSA Level 3 のプロベナンスを生成し、GitHub Release に `.intoto.jsonl` を自動アタッチする
- 各ビルドジョブで tarball の SHA256 を計算・アップロード、`aggregate-hashes` ジョブで集約して SLSA generator に渡す
- generator は SHA ピン（v2.0.0）で固定（SLSA Level 3 要件）

### ジョブの実行順序

```
build (matrix×6)
  ├─→ release          (タグ時のみ)
  ├─→ aggregate-hashes (タグ時のみ)
  └─→ provenance       (release + aggregate-hashes 完了後)
```

### ユーザーによる検証コマンド

```bash
slsa-verifier verify-artifact imagemagick-7.1.2-18-ubuntu22.04-x86_64.tar.gz \
  --provenance-path multiple.intoto.jsonl \
  --source-uri github.com/jksy/imagemagick-build
```

## Test plan

- [ ] バージョンタグ（`v*`）をプッシュして GitHub Actions を実行
- [ ] リリースページに `multiple.intoto.jsonl` がアタッチされることを確認
- [ ] `slsa-verifier` でプロベナンスを検証

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)