### PR TITLE
refactor: Claude設定をbest practicesに沿って整理

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,15 @@
             "command": "bash -c 'file=$(jq -r \".tool_input.file_path // empty\"); if [[ \"$file\" == *.sh ]]; then shellcheck \"$file\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'file=$(jq -r \".tool_input.file_path // empty\"); if [[ \"$file\" == */libraries.json ]]; then jq . \"$file\" > /dev/null && echo \"libraries.json: valid JSON\" || echo \"libraries.json: INVALID JSON\"; fi'"
+          }
+        ]
       }
     ]
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,6 @@ ImageMagickを必要なライブラリごとソースからビルドし、Ubuntu
 - `install.sh` — エンドユーザー向けワンライナーインストールスクリプト。
 - `.github/actions/build-imagemagick/action.yml` — ビルドを担う再利用可能コンポジットアクション。
 
-## Workflows
-
-| ファイル | トリガー | 目的 |
-|---|---|---|
-| `ci.yml` | PR to main | actionlint + マルチプラットフォームビルドテスト |
-| `build.yml` | タグ push / main push / 手動 | ビルド・リリース・SLSA provenance生成 |
-| `check-new-version.yml` | 毎週月曜 / 手動 | ImageMagick新バージョン検出・自動タグ付け |
-| `rebuild-on-library-update.yml` | main pushでlibraries.json変更時 | Renovate更新後の自動リビルド |
-| `test-installer.yml` | install.sh変更PR / 手動 | install.shの各OS動作確認 |
-
 ## リリースタグ命名規則
 
 - `vX.Y.Z-N` — 通常リリース (例: `v7.1.2-18-1`)。`-N` はビルド番号。
@@ -51,9 +41,3 @@ gh pr checks <PR番号>
 gh release list --limit 5
 ```
 
-## Hooks (自動実行)
-
-`.claude/settings.local.json` に以下のフックが設定されている:
-
-- **actionlint**: `.github/workflows/` または `.github/actions/` 以下のYAMLファイル保存時に自動実行
-- **shellcheck**: `.sh` ファイル保存時に自動実行


### PR DESCRIPTION
## Summary

- **CLAUDE.md** から冗長なセクションを削除
  - Workflows テーブル（YAMLファイルを読めばClaudeが自力で把握できる情報）
  - Hooks セクション（`settings.json` で管理済みで重複）
- **`.claude/settings.json`** に `libraries.json` 編集時の `jq` 構文チェックフックを追加
- **`.claude/settings.local.json`** の使い捨てパーミッションエントリを整理（gitignore対象のため別途ローカル適用済み）

## 参考

https://code.claude.com/docs/en/best-practices より:
> Exclude things Claude can figure out by reading the code, standard language conventions, detailed API documentation, frequently-changing information, long explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)