### PR TITLE
fix: SLSAプロベナンス生成の2つのバグを修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,14 +107,14 @@ jobs:
       - name: Compute SHA256
         run: |
           cd /tmp/artifacts
-          sha256sum ./*.tar.gz > /tmp/sha256sums.txt
-          cat /tmp/sha256sums.txt
+          sha256sum ./*.tar.gz > /tmp/sha256-${{ matrix.os_tag }}-${{ matrix.arch }}.txt
+          cat /tmp/sha256-${{ matrix.os_tag }}-${{ matrix.arch }}.txt
 
       - name: Upload SHA256
         uses: actions/upload-artifact@v7
         with:
           name: sha256-${{ matrix.os_tag }}-${{ matrix.arch }}
-          path: /tmp/sha256sums.txt
+          path: /tmp/sha256-${{ matrix.os_tag }}-${{ matrix.arch }}.txt
           retention-days: 7
 
   aggregate-hashes:
@@ -256,7 +256,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.aggregate-hashes.outputs.base64-subjects }}"
       upload-assets: true


### PR DESCRIPTION
## 問題

`Generate SLSA Provenance / final` ジョブが `SUCCESS: false` (exit code 27) で失敗していた。

## 原因

### 1. SHA256ファイルの上書き問題
各マトリクスビルドジョブが `/tmp/sha256sums.txt` という**同名ファイル**をアップロードしていた。`aggregate-hashes` ジョブで `merge-multiple: true` でダウンロードすると同じディレクトリに展開されて上書きが発生し、6つのうち1つのハッシュしか残らなかった。

実際に provenance に含まれていたのは1件のみ:
```
0f2850c...  ./imagemagick-7.1.2-18-amzn2023-aarch64.tar.gz
```

### 2. slsa-github-generator v2.0.0 の `final` ジョブ失敗
v2.0.0 (SHA: `5a775b3`) で `final` ジョブが `SUCCESS: false` になる既知の問題。

## 修正

- sha256ファイルをジョブごとにユニークな名前 (`sha256-<os>-<arch>.txt`) で出力するよう変更
- slsa-github-generator を v2.0.0 → v2.1.0 (`f7dd8c5`) にアップグレード

🤖 Generated with [Claude Code](https://claude.com/claude-code)