### PR TITLE
refactor: SLSAフレームワークをGitHubネイティブ attestation に置き換え

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # OIDC token for SLSA provenance generator
-  actions: read    # Required by slsa-github-generator
+  id-token: write      # OIDC token for artifact attestation
+  attestations: write  # GitHub native artifact attestation
 
 jobs:
   build:
@@ -103,40 +103,6 @@ jobs:
           name: imagemagick-${{ steps.build.outputs.imagemagick }}-${{ matrix.os_tag }}-${{ matrix.arch }}
           path: /tmp/artifacts/
           retention-days: 7
-
-      - name: Compute SHA256
-        run: |
-          cd /tmp/artifacts
-          sha256sum ./*.tar.gz > /tmp/sha256-${{ matrix.os_tag }}-${{ matrix.arch }}.txt
-          cat /tmp/sha256-${{ matrix.os_tag }}-${{ matrix.arch }}.txt
-
-      - name: Upload SHA256
-        uses: actions/upload-artifact@v7
-        with:
-          name: sha256-${{ matrix.os_tag }}-${{ matrix.arch }}
-          path: /tmp/sha256-${{ matrix.os_tag }}-${{ matrix.arch }}.txt
-          retention-days: 7
-
-  aggregate-hashes:
-    name: Aggregate SHA256 hashes
-    needs: build
-    runs-on: ubuntu-24.04
-    if: startsWith(github.ref, 'refs/tags/v')
-    outputs:
-      base64-subjects: ${{ steps.aggregate.outputs.base64-subjects }}
-    steps:
-      - name: Download all SHA256 files
-        uses: actions/download-artifact@v8
-        with:
-          pattern: sha256-*
-          merge-multiple: true
-          path: /tmp/sha256sums/
-
-      - name: Aggregate and base64-encode
-        id: aggregate
-        run: |
-          cat /tmp/sha256sums/*.txt > /tmp/all-sha256sums.txt
-          echo "base64-subjects=$(base64 -w0 < /tmp/all-sha256sums.txt)" >> "${GITHUB_OUTPUT}"
 
   release:
     name: Create GitHub Release
@@ -248,15 +214,25 @@ jobs:
             --title "ImageMagick ${{ steps.versions.outputs.imagemagick }}" \
             --notes-file /tmp/release_body.md
 
-  provenance:
-    name: Generate SLSA Provenance
-    needs: [release, aggregate-hashes]
+  attest:
+    name: Attest build provenance
+    needs: [build, release]
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      actions: read
       id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
-    with:
-      base64-subjects: "${{ needs.aggregate-hashes.outputs.base64-subjects }}"
-      upload-assets: true
+      attestations: write
+      contents: read
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: imagemagick-*
+          merge-multiple: true
+          path: /tmp/artifacts/
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: /tmp/artifacts/*.tar.gz


### PR DESCRIPTION
## 背景

SLSA framework (`slsa-github-generator`) で2つの問題が発生していた:

1. **`privacy-check` の誤検出** — Public リポジトリなのに「Repository is private」と判定され `generate-builder` が exit 2 で失敗
2. **`final` ジョブの `SUCCESS: false`** — 上記の連鎖で `generator.outputs.outcome = 'failure'` となり常に失敗

いずれも SLSA framework 側の問題で、upstream issue も見当たらない。

## 変更内容

- `slsa-github-generator` を完全に削除
- `aggregate-hashes` ジョブ・SHA256アーティファクトアップロードを削除（SLSA generator のためだけに存在していたため）
- `actions/attest@v4`（GitHub公式ドキュメント推奨）を使う `attest` ジョブを追加
- workflow permissions: `actions: read` 削除 → `attestations: write` 追加

## 動作確認

生成された attestation は以下で検証できる:
```bash
gh attestation verify <artifact-path> --repo jksy/imagemagick-build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)