### PR TITLE
fix: switch libde265 build from autotools to cmake

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -158,17 +158,12 @@ echo ""
 echo "=== Building libde265 ${DE265_VERSION} ==="
 clone_or_update https://github.com/strukturag/libde265.git \
   libde265 "v${DE265_VERSION}"
-cd libde265
-if [ ! -f configure ]; then
-  autoreconf -fi
-fi
-./configure --prefix="${PREFIX}" \
-  --enable-shared \
-  --disable-static \
-  --disable-sherlock265
-make -j"${NPROC}"
-make install
-cd "${BUILD_DIR}"
+cmake -S libde265 -B libde265/build \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DENABLE_SDL=OFF
+cmake --build libde265/build -j"${NPROC}"
+cmake --install libde265/build
 
 # ---------------------------------------------------------------------------
 # 8. libheif


### PR DESCRIPTION
## Summary

- libde265 v1.0.17 でオートツールのビルドスクリプト (`configure.ac`) が削除された
- v1.0.18 にアップデートした PR #46 の CI が全プラットフォームで `autoreconf: error: 'configure.ac' is required` で失敗していた
- libde265 のビルド方法を autotools から cmake に移行することで修正

## Test plan

- [ ] 全プラットフォーム (ubuntu22.04/24.04, amzn2023 × x86_64/aarch64) の CI が green になること
- [ ] PR #46 をマージ後も libde265 1.0.18 が正常にビルドできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)