### PR TITLE
security: add dependabot for GitHub Actions and pin all actions to SHA

### DIFF
--- a/.github/actions/build-imagemagick/action.yml
+++ b/.github/actions/build-imagemagick/action.yml
@@ -110,7 +110,7 @@ runs:
     - name: Restore library cache
       id: cache
       if: inputs.no_cache != 'true'
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: /opt/imagemagick
         key: v3-imagemagick-libs-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache_suffix }}-${{ steps.version-hash.outputs.hash }}
@@ -129,7 +129,7 @@ runs:
 
     - name: Upload test suite log on failure
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: imagemagick-test-suite-log-${{ runner.os }}-${{ runner.arch }}
         path: /tmp/imagemagick-build/imagemagick/tests/test-suite.log

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: dnf install -y tar git
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build and verify ImageMagick
         id: build
@@ -98,7 +98,7 @@ jobs:
           done
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: imagemagick-${{ steps.build.outputs.imagemagick }}-${{ matrix.os_tag }}-${{ matrix.arch }}
           path: /tmp/artifacts/
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Read versions
         id: versions
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: imagemagick-${{ steps.versions.outputs.imagemagick }}-*
           merge-multiple: true
@@ -190,7 +190,7 @@ jobs:
           BODYEOF
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ImageMagick ${{ steps.versions.outputs.imagemagick }}
@@ -226,13 +226,13 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: imagemagick-*
           merge-multiple: true
           path: /tmp/artifacts/
 
       - name: Attest build provenance
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-path: /tmp/artifacts/*.tar.gz

--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2
 
   build-and-test:
     name: Build and Test ImageMagick (${{ matrix.os_tag }}-${{ matrix.arch }})
@@ -54,7 +54,7 @@ jobs:
         run: dnf install -y tar git
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build and verify ImageMagick
         uses: ./.github/actions/build-imagemagick

--- a/.github/workflows/rebuild-on-library-update.yml
+++ b/.github/workflows/rebuild-on-library-update.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -48,7 +48,7 @@ jobs:
         run: dnf install -y git
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run install.sh
         env:
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run install.sh with custom path
         env:
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get latest release tag
         id: latest
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get latest release tag (strip v prefix)
         id: latest
@@ -177,7 +177,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get latest release tag (with v prefix)
         id: latest
@@ -214,7 +214,7 @@ jobs:
           apt-get install -y -qq git
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Expect failure on unsupported Ubuntu version
         run: |


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を新規追加。`github-actions` エコシステムのみを対象に週次でバージョンチェック（その他は Renovate がカバー）
- 全ワークフロー・composite action 内の `uses:` をバージョンタグから commit SHA にピニング。コメントで元のタグを明記（例: `actions/checkout@<sha> # v6`）

## Pinned actions

| Action | Tag | Commit SHA |
|--------|-----|------------|
| `actions/checkout` | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/upload-artifact` | v7 | `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` |
| `actions/download-artifact` | v8 | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `actions/cache` | v5 | `668228422ae6a00e4ad889ee87cd7109ec5666a7` |
| `actions/attest` | v4 | `59d89421af93a897026c735860bf21b6eb4f7b26` |
| `softprops/action-gh-release` | v2 | `153bb8e04406b158c6c84fc1615b65b24149a1fe` |
| `raven-actions/actionlint` | v2 | `205b530c5d9fa8f44ae9ed59f341a0db994aa6f8` |

## Test plan

- [ ] CI の actionlint ジョブが通ること
- [ ] CI の build-and-test ジョブが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)