### PR TITLE
feat: add VERSIONS file to build archive

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -22,7 +22,14 @@ echo "  Archive: ${ARCHIVE_PATH}"
 BUILD_DIR="${BUILD_DIR:-/tmp/imagemagick-build}"
 LICENSES_DIR="${PREFIX}/LICENSES"
 mkdir -p "${LICENSES_DIR}"
-trap 'rm -rf "${LICENSES_DIR}"' EXIT
+VERSIONS_FILE="${PREFIX}/VERSIONS"
+trap 'rm -rf "${LICENSES_DIR}" "${VERSIONS_FILE}"' EXIT
+
+echo "::group::Generating VERSIONS file"
+jq -r '.[] | select(.bundled == true) | "\(.name)=\(.version)"' "${LIBRARIES_FILE}" \
+  > "${VERSIONS_FILE}"
+cat "${VERSIONS_FILE}"
+echo "::endgroup::"
 
 collect_license() {
   local name="$1"


### PR DESCRIPTION
## Summary

- `scripts/package.sh` に `VERSIONS` ファイル生成処理を追加
- `libraries.json` の `bundled: true` なエントリから `NAME=VERSION` 形式のファイルを `${PREFIX}/VERSIONS` に生成
- `trap` に追加して EXIT 時にクリーンアップ（PREFIX を汚染しない）
- tar.gz は `${PREFIX}` 配下を丸ごと含めるため、変更なしで自動的にアーカイブに含まれる

## Test plan

- [x] `shellcheck scripts/package.sh` がクリーンであること
- [x] CI ビルドが成功すること
- [ ] `tar -tzf <archive>` で `imagemagick/<version>/VERSIONS` が含まれていること
- [ ] `VERSIONS` ファイルの内容が `NAME=VERSION` 形式であること

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)