### PR TITLE
fix: move license collection from package.sh to build.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,29 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Verify archive contents
+        run: |
+          echo "::group::Verifying archive contents"
+          fail=0
+          for archive in /tmp/artifacts/*.tar.gz; do
+            echo "--- ${archive##*/} ---"
+            license_count=$(tar -tzf "${archive}" | grep -cE 'LICENSES/.+\.txt$' || true)
+            if [ "${license_count}" -eq 0 ]; then
+              echo "  ERROR: no license files found" >&2
+              fail=1
+            else
+              echo "  OK: ${license_count} license file(s)"
+            fi
+            if tar -tzf "${archive}" | grep -qE 'VERSIONS$'; then
+              echo "  OK: VERSIONS file found"
+            else
+              echo "  ERROR: VERSIONS file not found" >&2
+              fail=1
+            fi
+          done
+          echo "::endgroup::"
+          exit "${fail}"
+
       - name: Update rolling release
         if: steps.tag_type.outputs.is_dated == 'true'
         env:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -224,5 +224,39 @@ fi
 
 cd "${BUILD_DIR}"
 
+# ---------------------------------------------------------------------------
+# Collect license files into PREFIX/LICENSES (persisted in cache)
+# ---------------------------------------------------------------------------
+LICENSES_DIR="${PREFIX}/LICENSES"
+mkdir -p "${LICENSES_DIR}"
+
+collect_license() {
+  local name="$1"
+  local src_dir="$2"
+  if [ ! -d "${src_dir}" ]; then
+    echo "  WARNING: source dir not found, skipping license for ${name}: ${src_dir}"
+    return
+  fi
+  for fname in LICENSE LICENSE.md LICENSE.txt COPYING COPYING.txt NOTICE NOTICE.md COPYRIGHT; do
+    if [ -f "${src_dir}/${fname}" ]; then
+      cp "${src_dir}/${fname}" "${LICENSES_DIR}/${name}.txt"
+      echo "  License: ${name} (${fname})"
+      return
+    fi
+  done
+  echo "  WARNING: no license file found for ${name} in ${src_dir}"
+}
+
+echo "::group::Collecting licenses"
+collect_license "libjpeg-turbo" "${BUILD_DIR}/libjpeg-turbo"
+collect_license "libpng"        "${BUILD_DIR}/libpng"
+collect_license "libtiff"       "${BUILD_DIR}/libtiff"
+collect_license "lcms2"         "${BUILD_DIR}/lcms2"
+collect_license "libaom"        "${BUILD_DIR}/libaom"
+collect_license "libwebp"       "${BUILD_DIR}/libwebp"
+collect_license "libheif"       "${BUILD_DIR}/libheif"
+collect_license "ImageMagick"   "${BUILD_DIR}/imagemagick"
+echo "::endgroup::"
+
 echo "=== Build complete ==="
 echo "  Installed to: ${PREFIX}"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -18,45 +18,13 @@ echo "=== Packaging ImageMagick ${IM_VERSION} ==="
 echo "  Source : ${PREFIX}"
 echo "  Archive: ${ARCHIVE_PATH}"
 
-# Collect license files from source directories into LICENSES/ inside PREFIX
-BUILD_DIR="${BUILD_DIR:-/tmp/imagemagick-build}"
-LICENSES_DIR="${PREFIX}/LICENSES"
-mkdir -p "${LICENSES_DIR}"
 VERSIONS_FILE="${PREFIX}/VERSIONS"
-trap 'rm -rf "${LICENSES_DIR}" "${VERSIONS_FILE}"' EXIT
+trap 'rm -rf "${VERSIONS_FILE}"' EXIT
 
 echo "::group::Generating VERSIONS file"
 jq -r '.[] | select(.bundled == true) | "\(.name)=\(.version)"' "${LIBRARIES_FILE}" \
   > "${VERSIONS_FILE}"
 cat "${VERSIONS_FILE}"
-echo "::endgroup::"
-
-collect_license() {
-  local name="$1"
-  local src_dir="$2"
-  if [ ! -d "${src_dir}" ]; then
-    echo "  WARNING: source dir not found, skipping license for ${name}: ${src_dir}"
-    return
-  fi
-  for fname in LICENSE LICENSE.md LICENSE.txt COPYING COPYING.txt NOTICE NOTICE.md COPYRIGHT; do
-    if [ -f "${src_dir}/${fname}" ]; then
-      cp "${src_dir}/${fname}" "${LICENSES_DIR}/${name}.txt"
-      echo "  License: ${name} (${fname})"
-      return
-    fi
-  done
-  echo "  WARNING: no license file found for ${name} in ${src_dir}"
-}
-
-echo "::group::Collecting licenses"
-collect_license "libjpeg-turbo" "${BUILD_DIR}/libjpeg-turbo"
-collect_license "libpng"        "${BUILD_DIR}/libpng"
-collect_license "libtiff"       "${BUILD_DIR}/libtiff"
-collect_license "lcms2"         "${BUILD_DIR}/lcms2"
-collect_license "libaom"        "${BUILD_DIR}/libaom"
-collect_license "libwebp"       "${BUILD_DIR}/libwebp"
-collect_license "libheif"       "${BUILD_DIR}/libheif"
-collect_license "ImageMagick"   "${BUILD_DIR}/imagemagick"
 echo "::endgroup::"
 
 # Create tarball with directory structure: imagemagick/<version>/...


### PR DESCRIPTION
## 問題

キャッシュヒット時、`package.sh` の `collect_license` が `BUILD_DIR`（`/tmp/imagemagick-build`）を参照していたが、キャッシュヒット時はビルドステップがスキップされるため `BUILD_DIR` が存在しない。その結果、ライセンスファイルがアーカイブに含まれなかった。

## 対応

- `collect_license` 処理を `build.sh` の末尾に移動
- ビルド時に `${PREFIX}/LICENSES` へライセンスを収集するため、キャッシュと一緒に保存される
- `package.sh` からはライセンス収集コードを削除（`VERSIONS` ファイル生成のみ残す）
- リリース作成後に各 tar.gz の内容を検証するステップを追加（`LICENSES/*.txt` と `VERSIONS` の存在確認）

## Test plan

- [ ] CI フルビルド（キャッシュなし）で `LICENSES/` がアーカイブに含まれること
- [x] キャッシュヒット時のビルドで `LICENSES/` がアーカイブに含まれること
- [x] リリース後の検証ステップが `LICENSES/*.txt` と `VERSIONS` の存在を確認すること
- [x] `shellcheck scripts/build.sh scripts/package.sh` がクリーンであること
- [x] `actionlint` がクリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)