### PR TITLE
fix: ignore Ubuntu runner version updates in test-installer.yml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,6 +95,11 @@
   ],
   "packageRules": [
     {
+      "matchFileNames": [".github/workflows/test-installer.yml"],
+      "matchDepPatterns": ["^ubuntu"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"
     },


### PR DESCRIPTION
## Summary

- `renovate.json` に `packageRule` を追加し、`.github/workflows/test-installer.yml` 内の Ubuntu ランナーバージョン (`ubuntu-22.04` / `ubuntu-24.04`) を Renovate の更新対象から除外
- このファイルの Ubuntu バージョンは異なる環境での ImageMagick ビルドテスト用に意図的に設定されているため、自動更新は不要

Closes #65

## Test plan

- [x] `jq . renovate.json` で JSON 構文が正常であることを確認
- [ ] Renovate を再実行し `test-installer.yml` の Ubuntu バージョン更新 PR が生成されないことを確認
- [ ] 他ワークフローの `actions/checkout` 等のバージョン更新は引き続き PR が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)