### PR TITLE
fix: comply with branch protection by using PR-based flow for IM version bump

### DIFF
--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   check:
@@ -77,25 +78,31 @@ jobs:
           git tag "v${NEW}"
           git push origin "v${NEW}"
 
-      # --- 自動検出: main を更新してタグを打つ ---
+      # --- 自動検出: ブランチ+PR で main を更新してタグを打つ ---
       - name: Bump to latest version (auto)
         if: |
           steps.target.outputs.manual == 'false' &&
           steps.tag_check.outputs.exists == 'false' &&
           steps.target.outputs.version != steps.current.outputs.version
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           NEW="${{ steps.target.outputs.version }}"
+          BRANCH="bump/imagemagick-${NEW}"
           echo "Bumping ImageMagick from ${{ steps.current.outputs.version }} to ${NEW}"
-          jq --arg v "${NEW}" '(.[] | select(.key == "imagemagick") | .version) = $v' libraries.json \
-            > libraries.json.tmp && mv libraries.json.tmp libraries.json
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          jq --arg v "${NEW}" '(.[] | select(.key == "imagemagick") | .version) = $v' libraries.json \
+            > libraries.json.tmp && mv libraries.json.tmp libraries.json
           git add libraries.json
           git commit -m "chore: bump ImageMagick to ${NEW}"
-          git tag "v${NEW}"
-          git pull --rebase origin main
-          git push origin main
-          git push origin "v${NEW}"
+          git push origin "${BRANCH}"
+          gh pr create \
+            --title "chore: bump ImageMagick to ${NEW}" \
+            --body "ImageMagick ${NEW} が公開されたため、自動バージョンアップします。" \
+            --base main \
+            --head "${BRANCH}"
 
       - name: No update needed
         if: steps.tag_check.outputs.exists == 'true'

--- a/.github/workflows/rebuild-on-library-update.yml
+++ b/.github/workflows/rebuild-on-library-update.yml
@@ -25,15 +25,18 @@ jobs:
           IM_VERSION=$(jq -r '.[] | select(.key == "imagemagick") | .version' libraries.json)
           echo "im_version=${IM_VERSION}" >> "${GITHUB_OUTPUT}"
 
-          # If the imagemagick version itself changed, this is an IM bump committed by
-          # check-new-version.yml — that workflow already handles tag creation, so skip here.
+          # If the imagemagick version itself changed, create the v{IM_VERSION} tag here
+          # so that the release build is triggered only after the PR is merged to main.
           PREV_IM=$(git show HEAD~1:libraries.json 2>/dev/null \
             | jq -r '.[] | select(.key == "imagemagick") | .version' 2>/dev/null || echo "")
           if [ "${PREV_IM}" != "${IM_VERSION}" ]; then
             echo "is_library_update=false" >> "${GITHUB_OUTPUT}"
-            echo "ImageMagick version changed (${PREV_IM} → ${IM_VERSION}) — check-new-version.yml handles this"
+            echo "is_im_bump=true" >> "${GITHUB_OUTPUT}"
+            echo "ImageMagick version changed (${PREV_IM} → ${IM_VERSION}) — will create release tag"
             exit 0
           fi
+
+          echo "is_im_bump=false" >> "${GITHUB_OUTPUT}"
 
           # IM version is unchanged. If v{IM_VERSION} tag already exists,
           # this is a library-only rebuild.
@@ -44,6 +47,16 @@ jobs:
             echo "is_library_update=false" >> "${GITHUB_OUTPUT}"
             echo "Tag v${IM_VERSION} does not exist yet — skipping"
           fi
+
+      - name: Create release tag for ImageMagick bump
+        if: steps.check.outputs.is_im_bump == 'true'
+        run: |
+          IM_VERSION="${{ steps.check.outputs.im_version }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${IM_VERSION}"
+          git push origin "v${IM_VERSION}"
+          echo "Created release tag: v${IM_VERSION}"
 
       - name: Create snapshot tag
         if: steps.check.outputs.is_library_update == 'true'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,103 @@
+# リリースフロー
+
+## タグ命名規則
+
+| パターン | 例 | 用途 |
+|---|---|---|
+| `v{IM_VERSION}` | `v7.1.2-19` | ImageMagick バージョンアップ時の正規リリース |
+| `v{IM_VERSION}-{YYYYMMDD}` | `v7.1.2-18-20260415` | ライブラリのみ更新時のスナップショット |
+| `v{IM_VERSION}-{YYYYMMDD}-{N}` | `v7.1.2-18-20260415-2` | 同日に複数回スナップショットが作られた場合 |
+
+---
+
+## ケース 1: ImageMagick バージョンアップ（自動・毎週月曜）
+
+```
+check-new-version.yml（毎週月曜 09:00 UTC に起動）
+  └─ 最新バージョンを検出
+  └─ bump/imagemagick-{NEW} ブランチを作成・push
+  └─ main への PR を作成（タグはまだ作らない）
+
+↓ CI（ci.yml）が PR を検証
+
+↓ PR をマージ
+
+rebuild-on-library-update.yml（main への push を検知）
+  └─ IM バージョン変更を検出
+  └─ v{NEW} タグを作成・push
+
+↓ build.yml（v* タグで起動）
+
+  build ジョブ: 6プラットフォーム並列ビルド
+    Ubuntu 22.04 / 24.04 × x86_64 / aarch64
+    Amazon Linux 2023  × x86_64 / aarch64
+
+  release ジョブ: GitHub Release を作成（tar.gz + SBOM）
+
+  attest ジョブ: ビルド来歴の attestation を生成
+```
+
+**タグ形式:** `v7.1.2-19`
+
+---
+
+## ケース 2: ライブラリのみ更新（Renovate による自動 PR）
+
+```
+Renovate
+  └─ libraries.json を更新する PR を作成
+
+↓ CI が PR を検証
+
+↓ PR をマージ
+
+rebuild-on-library-update.yml（main への push を検知）
+  └─ IM バージョンは変わっていないことを確認
+  └─ 日付付きスナップショットタグを作成・push（v{IM_VERSION}-{YYYYMMDD}）
+
+↓ build.yml（v* タグで起動）
+
+  build / release / attest ジョブ（ケース 1 と同様）
+
+  release ジョブ追加処理:
+    └─ ローリングリリース v{IM_VERSION} のアセットも上書き更新
+```
+
+**タグ形式:** `v7.1.2-18-20260415`
+
+> スナップショットリリースは独立した GitHub Release として作成される。
+> さらにローリングリリース（`v7.1.2-18`）のアセットも最新に上書きされるため、
+> バージョンを固定せずインストールするユーザーは常に最新ライブラリ入りを取得できる。
+
+---
+
+## ケース 3: 特定バージョンの手動ビルド
+
+Actions タブから `Check for new ImageMagick release` を `workflow_dispatch` で起動し、
+`version` 入力欄にビルドしたいバージョン（例: `7.1.2-10`）を指定する。
+
+```
+check-new-version.yml（workflow_dispatch）
+  └─ 指定バージョンを一時ブランチ build-{VERSION} でコミット
+  └─ タグ v{VERSION} のみ push（main・PR は作らない）
+
+↓ build.yml（v* タグで起動）
+
+  build / release / attest ジョブ（ケース 1 と同様）
+```
+
+**タグ形式:** `v7.1.2-10`（正規リリースと同じ形式）
+
+> main は変更されない。過去バージョンや緊急ビルドに使う。
+
+---
+
+## 関連ワークフロー早見表
+
+| ファイル | トリガー | 役割 |
+|---|---|---|
+| `check-new-version.yml` | 毎週月曜 / 手動 | IM バージョン検出・bump ブランチ作成・PR 作成 |
+| `rebuild-on-library-update.yml` | main への push（libraries.json 変更時） | タグ作成（IM バージョンアップ時は `v{NEW}`、ライブラリのみ更新時は日付付き） |
+| `build.yml` | `v*` タグ push / main への push / 手動 | ビルド・リリース・attestation |
+| `ci.yml` | main への PR | lint・shellcheck など基本検証 |
+| `test-installer.yml` | install.sh 変更を含む PR | インストールスクリプトの動作確認 |


### PR DESCRIPTION
## 背景

`check-new-version.yml` が `git push origin main` で直接 main に push しようとしていたが、ブランチ保護ルール（PR 必須）に違反してエラーになっていた。

ref: https://github.com/jksy/imagemagick-build/actions/runs/24458278498/job/71464953586

## 変更内容

### check-new-version.yml
- 自動検出パスの `git push origin main` を廃止
- `bump/imagemagick-{version}` ブランチを作成して push し、`gh pr create` で PR を作成するフローに変更
- タグ作成は PR マージ後に `rebuild-on-library-update.yml` に委譲（未レビューコードでリリースビルドが走るのを防ぐ）

### rebuild-on-library-update.yml
- IM バージョン変更時に「skip」していた箇所を、`v{NEW}` タグを作成するよう変更

### リリースフロー（変更後）

```
check-new-version.yml: bump ブランチ作成 + PR（タグなし）
  ↓ CI 通過・PR マージ
rebuild-on-library-update.yml: v{NEW} タグ作成
  ↓
build.yml: リリースビルド
```

### RELEASE.md
全リリースフロー（IM バージョンアップ／ライブラリのみ更新／手動ビルド）を文書化。

## マージ順

このPRを最初にマージしてください。