### PR TITLE
fix: ignore Ubuntu runner version updates in test-installer.yml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,6 +95,7 @@
   ],
   "packageRules": [
     {
+      "description": "Ubuntu versions in test-installer.yml are intentional test matrix entries (test targets), not dependency updates",
       "matchFileNames": [".github/workflows/test-installer.yml"],
       "matchDepPatterns": ["^ubuntu"],
       "enabled": false


### PR DESCRIPTION
## 変更内容

`renovate.json` の Ubuntu バージョン無視ルールに `description` フィールドを追加。

`test-installer.yml` の `ubuntu-22.04` / `ubuntu-24.04` はテストマトリクスのターゲット（テスト対象 OS）であり、GitHub Actions のランナーバージョンとしての依存関係ではないため、Renovate の自動更新対象から除外している。その理由をコード上に残す。