### PR TITLE
fix: use git-tags datasource for libwebp

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,8 +54,8 @@
         "/^libraries\\.json$/"
       ],
       "matchStrings": ["\"key\":\\s*\"libwebp\"[\\s\\S]*?\"version\":\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "webmproject/libwebp",
-      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "https://github.com/webmproject/libwebp",
+      "datasourceTemplate": "git-tags",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^v?(?<version>.+)$"
     },


### PR DESCRIPTION
## Summary

- `webmproject/libwebp` はGitHub Releasesを公開しておらずタグのみ管理しているため、`github-releases` datasourceでは更新を検出できなかった
- `datasourceTemplate` を `git-tags` に変更し、`depNameTemplate` を完全なリポジトリURLに修正
- これにより Renovate が libwebp 1.6.0 へのPRを作成できるようになる

## Test plan

- [ ] このPRマージ後、Renovate が libwebp 1.6.0 へのアップデートPRを作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)