### PR TITLE
fix: use git-tags datasource for libpng

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,8 @@
         "/^libraries\\.json$/"
       ],
       "matchStrings": ["\"key\":\\s*\"libpng\"[\\s\\S]*?\"version\":\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "glennrp/libpng",
-      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "https://github.com/glennrp/libpng",
+      "datasourceTemplate": "git-tags",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^v?(?<version>.+)$"
     },


### PR DESCRIPTION
## Summary

- `glennrp/libpng` はGitHub Releasesを公開しておらずタグのみ管理しているため、`github-releases` datasourceでは更新を検出できなかった
- `datasourceTemplate` を `git-tags` に変更し、`depNameTemplate` を完全なリポジトリURLに修正
- libwebp の同様修正（#75）に続くもの

## Test plan

- [ ] このPRマージ後、Renovate が libpng 1.6.58 へのアップデートPRを作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)