### PR TITLE
fix: exclude libpng pre-release tags (alpha/beta/rc)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -109,6 +109,11 @@
     {
       "matchManagers": ["custom.regex"],
       "groupName": "bundled libraries"
+    },
+    {
+      "description": "libpng uses git-tags with alpha/beta/rc pre-releases — only track stable releases",
+      "matchDepNames": ["https://github.com/glennrp/libpng"],
+      "allowedVersions": "!/alpha|beta|rc/i"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- libpng は安定版に加えて alpha/beta/rc タグを公開しており、Renovate が `1.7.0beta89` のような事前リリース版をプロポーズしてしまう（[#76](https://github.com/jksy/imagemagick-build/pull/76) 参照）
- `allowedVersions: "!/alpha|beta|rc/i"` を追加し、安定版のみを対象にする

## Test plan

- [ ] このPRマージ後、Renovate が libpng の安定版（`1.6.58`）へのPRを作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)