### PR TITLE
chore: bump ImageMagick to 7.1.2-21

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -2,7 +2,7 @@
   {
     "key": "imagemagick",
     "name": "ImageMagick",
-    "version": "7.1.2-19",
+    "version": "7.1.2-21",
     "purl_base": "pkg:github/ImageMagick/ImageMagick",
     "bundled": true,
     "repo": "https://github.com/ImageMagick/ImageMagick.git"


### PR DESCRIPTION
ImageMagick 7.1.2-21 が公開されたため、自動バージョンアップします。