### PR TITLE
chore: bump ImageMagick to 7.1.2-23

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ JPEG, PNG, TIFF, WebP, AVIF, HEIC (read), PDF
 <!-- BUNDLED_LIBRARIES_START -->
 | Library | Version |
 |---|---|
-| ImageMagick | 7.1.2-21 |
+| ImageMagick | 7.1.2-23 |
 | libjpeg-turbo | 3.1.4.1 |
 | libpng | 1.6.58 |
 | libtiff | 4.7.1 |

--- a/libraries.json
+++ b/libraries.json
@@ -2,7 +2,7 @@
   {
     "key": "imagemagick",
     "name": "ImageMagick",
-    "version": "7.1.2-21",
+    "version": "7.1.2-23",
     "purl_base": "pkg:github/ImageMagick/ImageMagick",
     "bundled": true,
     "repo": "https://github.com/ImageMagick/ImageMagick.git"


### PR DESCRIPTION
ImageMagick 7.1.2-23 が公開されたため、自動バージョンアップします。