### PR TITLE
fix(sync-readme): checkout 衝突で auto-sync が失敗する問題を修正

### DIFF
--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -49,7 +49,10 @@ jobs:
           cp README.md "${NEW_README_TMP}"
 
           git fetch origin "${HEAD_REF}"
-          git checkout -B "${HEAD_REF}" "origin/${HEAD_REF}"
+          # -f discards the README.md change made by sync-readme.sh in the
+          # working tree (already saved to NEW_README_TMP above) so the
+          # checkout to the PR head ref does not abort.
+          git checkout -f -B "${HEAD_REF}" "origin/${HEAD_REF}"
           cp "${NEW_README_TMP}" README.md
 
           git config user.name  "github-actions[bot]"


### PR DESCRIPTION
## 概要

[PR #83](https://github.com/jksy/imagemagick-build/pull/83) などで `Auto-sync README.md to libraries.json` ジョブが以下のエラーで失敗していたのを修正します。

```
error: Your local changes to the following files would be overwritten by checkout:
	README.md
Please commit your changes or stash them before you switch branches.
Aborting
```

## 原因

`Push README change to PR branch` ステップで、

1. `sync-readme.sh` が README.md を上書き
2. README.md を tmp に退避
3. `git checkout -B "${HEAD_REF}" "origin/${HEAD_REF}"` で PR ブランチに切替

の流れになっていますが、3 の時点で作業ツリーに未コミットの README.md 変更が残っているため checkout が abort していました。

## 修正

退避済みなので作業ツリーの変更は捨てて問題なし。`git checkout` に `-f` を付けて強制切替するようにしました。

## テスト

- [x] このワークフロー修正を main にマージ後、PR #83 を再走させて auto-sync が成功すること（→ 別の問題が顕在化し PR #85 で追加修正）