### PR TITLE
fix(sync-readme): PR ブランチが既に最新の場合 commit を skip する

### DIFF
--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -55,6 +55,13 @@ jobs:
           git checkout -f -B "${HEAD_REF}" "origin/${HEAD_REF}"
           cp "${NEW_README_TMP}" README.md
 
+          # The PR branch may already contain the regenerated README (e.g. the
+          # bumper bot updated it). In that case there is nothing to commit.
+          if git diff --quiet README.md; then
+            echo "PR branch README.md is already up to date."
+            exit 0
+          fi
+
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md


### PR DESCRIPTION
## 概要

[PR #84](https://github.com/jksy/imagemagick-build/pull/84) のマージ後、PR #83 で再走させた auto-sync ジョブが以下のステップで失敗していました。

[失敗ジョブ](https://github.com/jksy/imagemagick-build/actions/runs/26360492444/job/77594918989?pr=83)

```
On branch bump/imagemagick-7.1.2-23
nothing to commit, working tree clean
##[error]Process completed with exit code 1.
```

## 原因

main の README から見ると diff があるため最初の `git diff --quiet` は通過しますが、PR ブランチに切り替えた直後の README はすでに最新（bumper bot が含めて push 済み）なため、`cp` 後の `git commit` が `nothing to commit` で exit 1 となり、`set -e` でジョブ全体が失敗していました。

## 修正

PR ブランチに README をコピーした直後にもう一度 `git diff --quiet README.md` を行い、差分が無ければ `exit 0` で正常終了するようにしました。

## テスト

- [ ] マージ後、PR #83 で auto-sync を再走し、ジョブが success になること