### PR TITLE
fix(build): prefer bundled libs in CMake-based builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -67,6 +67,7 @@ clone_or_update https://github.com/libjpeg-turbo/libjpeg-turbo.git \
   libjpeg-turbo "${JPEG_VERSION}"
 cmake -S libjpeg-turbo -B libjpeg-turbo/build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DENABLE_SHARED=1 \
   -DENABLE_STATIC=0
@@ -91,21 +92,7 @@ cd "${BUILD_DIR}"
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------
-# 3. libtiff
-# ---------------------------------------------------------------------------
-echo "::group::Building libtiff ${TIFF_VERSION}"
-clone_or_update https://gitlab.com/libtiff/libtiff.git \
-  libtiff "v${TIFF_VERSION}"
-cmake -S libtiff -B libtiff/build \
-  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-  -DCMAKE_INSTALL_LIBDIR=lib \
-  -DBUILD_SHARED_LIBS=ON
-cmake --build libtiff/build -j"${NPROC}"
-cmake --install libtiff/build
-echo "::endgroup::"
-
-# ---------------------------------------------------------------------------
-# 4. lcms2
+# 3. lcms2
 # ---------------------------------------------------------------------------
 echo "::group::Building lcms2 ${LCMS_VERSION}"
 clone_or_update https://github.com/mm2/Little-CMS.git \
@@ -121,13 +108,14 @@ cd "${BUILD_DIR}"
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------
-# 5. libaom
+# 4. libaom
 # ---------------------------------------------------------------------------
 echo "::group::Building libaom ${AOM_VERSION}"
 clone_or_update https://aomedia.googlesource.com/aom \
   libaom "v${AOM_VERSION}"
 cmake -S libaom -B libaom/build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DBUILD_SHARED_LIBS=1 \
   -DENABLE_TESTS=0
@@ -136,7 +124,7 @@ cmake --install libaom/build
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------
-# 6. libwebp
+# 5. libwebp (built before libtiff so libtiff can pick it up)
 # ---------------------------------------------------------------------------
 echo "::group::Building libwebp ${WEBP_VERSION}"
 clone_or_update https://github.com/webmproject/libwebp.git \
@@ -152,6 +140,21 @@ cd "${BUILD_DIR}"
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------
+# 6. libtiff
+# ---------------------------------------------------------------------------
+echo "::group::Building libtiff ${TIFF_VERSION}"
+clone_or_update https://gitlab.com/libtiff/libtiff.git \
+  libtiff "v${TIFF_VERSION}"
+cmake -S libtiff -B libtiff/build \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=ON
+cmake --build libtiff/build -j"${NPROC}"
+cmake --install libtiff/build
+echo "::endgroup::"
+
+# ---------------------------------------------------------------------------
 # 7. libde265
 # ---------------------------------------------------------------------------
 echo ""
@@ -160,6 +163,7 @@ clone_or_update https://github.com/strukturag/libde265.git \
   libde265 "v${DE265_VERSION}"
 cmake -S libde265 -B libde265/build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DENABLE_SDL=OFF
 cmake --build libde265/build -j"${NPROC}"
@@ -173,12 +177,14 @@ clone_or_update https://github.com/strukturag/libheif.git \
   libheif "v${HEIF_VERSION}"
 cmake -S libheif -B libheif/build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DWITH_AOM_DECODER=ON \
   -DWITH_AOM_ENCODER=ON \
   -DWITH_LIBDE265=ON \
   -DWITH_X265=OFF \
   -DWITH_DAV1D=OFF \
+  -DWITH_EXAMPLES=OFF \
   -DENABLE_TESTING=OFF
 cmake --build libheif/build -j"${NPROC}"
 cmake --install libheif/build


### PR DESCRIPTION
## Summary

- CMake の `find_package(PNG/JPEG/TIFF/...)` は `PKG_CONFIG_PATH` を無視して `/usr` を優先探索するため、依存ライブラリのビルドがシステム版を拾い、`${PREFIX}` に新しく入れたバンドル版が使われていなかった
- libheif 1.22.0 の examples が新しい libpng API (`png_set_cICP` / `png_set_cLLI_fixed` / `png_set_mDCV_fixed` — バンドル libpng 1.6.58 にはあるがシステム libpng 1.6.37/1.6.43 には無い) を要求し、リンクエラーで CI が全プラットフォーム失敗していた ([PR #86](https://github.com/jksy/imagemagick-build/pull/86) で発覚)
- すべての CMake 呼び出しに `-DCMAKE_PREFIX_PATH=\${PREFIX}` を追加してバンドル版を優先検出させる。あわせて libwebp を libtiff より先にビルドし、libheif は不要な examples (`-DWITH_EXAMPLES=OFF`) を無効化

## Test plan

- [x] CI の全プラットフォーム（ubuntu22.04/24.04 × x86_64/aarch64, amzn2023 × x86_64/aarch64）が green
- [x] verify ジョブで HEIC/WebP/JPEG/PNG/TIFF が `identify -list format` に出ること
- [ ] マージ後 PR #86 を rebase し、libheif 1.22.0 + libde265 1.0.19 + libaom 3.14.1 の組合せでも green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)