### PR TITLE
fix(build): patch libheif 1.22.0 header for C compatibility

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -188,6 +188,17 @@ cmake -S libheif -B libheif/build \
   -DENABLE_TESTING=OFF
 cmake --build libheif/build -j"${NPROC}"
 cmake --install libheif/build
+
+# TODO(libheif-1.22.1): remove this patch once libheif >= 1.22.1 is released.
+# libheif 1.22.0 ships a header where `heif_bad_pixel` is referenced without
+# the `struct` keyword and without a typedef, which breaks C consumers such as
+# ImageMagick's coders/heic.c. Upstream added the typedef post-1.22.0:
+# https://github.com/strukturag/libheif/commits/master/libheif/api/libheif/heif_properties.h
+if [ "${HEIF_VERSION}" = "1.22.0" ]; then
+  echo "  Applying libheif 1.22.0 header workaround (heif_bad_pixel typedef)"
+  sed -i 's|^struct heif_bad_pixel { uint32_t row; uint32_t column; };|typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;|' \
+    "${PREFIX}/include/libheif/heif_properties.h"
+fi
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- libheif 1.22.0 の [`heif_properties.h`](https://github.com/strukturag/libheif/blob/v1.22.0/libheif/api/libheif/heif_properties.h#L322-L338) は `struct heif_bad_pixel` を typedef なしで宣言した上で、L338/L366 で `heif_bad_pixel*` と bare 参照している。C++ では通るが **C では未定義型**となり、ImageMagick の `coders/heic.c` のビルドが失敗する ([PR #86](https://github.com/jksy/imagemagick-build/pull/86) で発覚)
- upstream master では既に typedef を追加済み (修正は libheif 1.22.1 で提供予定)。それまでの暫定として install 直後の `heif_properties.h` に `sed` で typedef を付与
- バージョンガード `if [ "${HEIF_VERSION}" = "1.22.0" ]` 付きで、`libraries.json` が 1.22.1+ に bump された瞬間に自動的に無効化される（消し忘れても害なし）

## Test plan

- [ ] PR #86 (libheif 1.22.0 + libde265 1.0.19 + libaom 3.14.1) を rebase して CI 全プラットフォーム green
- [ ] libheif 1.22.1 リリース後、Renovate PR を merge した上で本ブロック (TODO コメント付き) を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)