### PR TITLE
fix: build libjpeg-turbo with -fPIC for AL2023 shared lib link

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -72,7 +72,8 @@ cmake -S libjpeg-turbo -B libjpeg-turbo/build \
   -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DENABLE_SHARED=1 \
-  -DENABLE_STATIC=0
+  -DENABLE_STATIC=0 \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 cmake --build libjpeg-turbo/build -j"${NPROC}"
 cmake --install libjpeg-turbo/build
 echo "::endgroup::"


### PR DESCRIPTION
## 背景

[#108](https://github.com/jksy/imagemagick-build/pull/108)（libjpeg-turbo `3.1.4.1` → `3.2.0`）の CI で `amzn2023-x86_64` ビルドのみが失敗していた。

## 原因

libjpeg-turbo 3.2.0 で PNG 読み書きサポートが追加され、ビルドツリーに bundled な spng + 静的 zlib（`zlib-static`）が取り込まれるようになった。共有ライブラリ `libturbojpeg.so` をリンクする際、この静的 zlib オブジェクトが PIC でないため x86_64 でリンクエラーになる:

```
/usr/bin/ld: .../zlib-static.dir/zlib/compress.c.o: relocation R_X86_64_32
  against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
```

Ubuntu のツールチェーンはデフォルトでこれらを PIC ビルドするため通っており、`R_X86_64_32` は x86 固有の再配置なので aarch64 でも顕在化しない。結果として **AL2023 x86_64 のみ**失敗していた。

## 修正

`scripts/build.sh` の libjpeg-turbo cmake configure に `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` を追加。bundled 静的 zlib が `-fPIC` でビルドされ、共有ライブラリにリンクできるようになる。

マージ後、[#108](https://github.com/jksy/imagemagick-build/pull/108) を rebase/retry すれば CI が通る想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)