### PR TITLE
feat: add no-openmp build variant

### DIFF
--- a/.github/actions/build-imagemagick/action.yml
+++ b/.github/actions/build-imagemagick/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Set to "true" to skip cache restore and force full rebuild'
     required: false
     default: 'false'
+  disable_openmp:
+    description: 'Set to "true" to build ImageMagick with --disable-openmp (the no-openmp variant)'
+    required: false
+    default: 'false'
 
 outputs:
   imagemagick:
@@ -113,7 +117,10 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: /opt/imagemagick
-        key: v3-imagemagick-libs-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache_suffix }}-${{ steps.version-hash.outputs.hash }}
+        # The variant is part of the key (not left to cache_suffix) so that a
+        # caller forgetting to disambiguate can never restore an OpenMP build
+        # into a no-openmp job or vice versa.
+        key: v4-imagemagick-libs-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache_suffix }}-${{ inputs.disable_openmp == 'true' && 'no-openmp' || 'default' }}-${{ steps.version-hash.outputs.hash }}
 
     - name: Build all libraries and ImageMagick
       if: steps.cache.outputs.cache-hit != 'true'
@@ -121,6 +128,7 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
         SKIP_TESTS: ${{ inputs.skip_tests == 'true' && '1' || '0' }}
+        DISABLE_OPENMP: ${{ inputs.disable_openmp == 'true' && '1' || '0' }}
       run: |
         chmod +x scripts/build.sh
         LIBRARIES_FILE="${{ inputs.version_file }}" \
@@ -131,13 +139,18 @@ runs:
       if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: imagemagick-test-suite-log-${{ runner.os }}-${{ runner.arch }}
+        # cache_suffix (os_tag-arch) disambiguates jobs that share the same
+        # runner.os/arch, e.g. the amzn2023 container builds and the two
+        # OpenMP variants.
+        name: imagemagick-test-suite-log-${{ inputs.cache_suffix }}-${{ inputs.disable_openmp == 'true' && 'no-openmp' || 'default' }}
         path: /tmp/imagemagick-build/imagemagick/tests/test-suite.log
         if-no-files-found: ignore
         retention-days: 7
 
     - name: Verify build
       shell: bash
+      env:
+        DISABLE_OPENMP: ${{ inputs.disable_openmp == 'true' && '1' || '0' }}
       run: |
         chmod +x scripts/verify.sh
         PREFIX=/opt/imagemagick bash scripts/verify.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,24 @@ permissions:
 
 jobs:
   build:
-    name: Build ImageMagick (${{ matrix.os_tag }}-${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container || '' }}
+    name: Build ImageMagick (${{ matrix.target.os_tag }}-${{ matrix.target.arch }}, ${{ matrix.variant.name }})
+    runs-on: ${{ matrix.target.runner }}
+    container: ${{ matrix.target.container || '' }}
     strategy:
       fail-fast: false
       matrix:
-        include:
+        # Every target is built in two variants: "default" (OpenMP enabled)
+        # and "no-openmp" (ImageMagick configured with --disable-openmp) for
+        # hosts that run many ImageMagick processes concurrently. The variant
+        # suffix becomes part of the release asset name.
+        variant:
+          - name: default
+            suffix: ''
+            disable_openmp: 'false'
+          - name: no-openmp
+            suffix: '-no-openmp'
+            disable_openmp: 'true'
+        target:
           - runner: ubuntu-22.04
             os_tag: ubuntu22.04
             arch: x86_64
@@ -58,7 +69,7 @@ jobs:
 
     steps:
       - name: Install tar and git (AL2023 minimal container)
-        if: matrix.os_tag == 'amzn2023'
+        if: matrix.target.os_tag == 'amzn2023'
         run: dnf install -y tar git
 
       - name: Checkout
@@ -69,9 +80,10 @@ jobs:
         uses: ./.github/actions/build-imagemagick
         with:
           version_file: ${{ github.event.inputs.version_file || 'libraries.json' }}
-          cache_suffix: ${{ matrix.os_tag }}-${{ matrix.arch }}
+          cache_suffix: ${{ matrix.target.os_tag }}-${{ matrix.target.arch }}
           skip_tests: ${{ github.event.inputs.skip_tests || 'false' }}
           no_cache: ${{ github.event.inputs.no_cache || 'false' }}
+          disable_openmp: ${{ matrix.variant.disable_openmp }}
 
       - name: Package build
         run: |
@@ -80,8 +92,9 @@ jobs:
           SUDO_CMD="$(command -v sudo 2>/dev/null || true)"
           $SUDO_CMD env \
                LIBRARIES_FILE="${{ steps.build.outputs.version_file }}" \
-               OS_TAG=${{ matrix.os_tag }} \
-               ARCH=${{ matrix.arch }} \
+               OS_TAG=${{ matrix.target.os_tag }} \
+               ARCH=${{ matrix.target.arch }} \
+               VARIANT=${{ matrix.variant.name }} \
                PREFIX=/opt/imagemagick \
                ARCHIVE_DIR=/tmp/artifacts \
                bash scripts/package.sh
@@ -92,15 +105,15 @@ jobs:
           for tarball in /tmp/artifacts/*.tar.gz; do
             sbom="${tarball%.tar.gz}.sbom.json"
             LIBRARIES_FILE="${{ steps.build.outputs.version_file }}" \
-              OS_TAG=${{ matrix.os_tag }} \
-              ARCH=${{ matrix.arch }} \
+              OS_TAG=${{ matrix.target.os_tag }} \
+              ARCH=${{ matrix.target.arch }} \
               bash scripts/generate-sbom.sh "$sbom"
           done
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: imagemagick-${{ steps.build.outputs.imagemagick }}-${{ matrix.os_tag }}-${{ matrix.arch }}
+          name: imagemagick-${{ steps.build.outputs.imagemagick }}-${{ matrix.target.os_tag }}-${{ matrix.target.arch }}${{ matrix.variant.suffix }}
           path: /tmp/artifacts/
           retention-days: 7
 
@@ -176,6 +189,11 @@ jobs:
 
           JPEG · PNG · TIFF · WebP · AVIF · PDF
 
+          ### Variants
+
+          - \`imagemagick-<ver>-<os>-<arch>.tar.gz\` — default build (OpenMP enabled)
+          - \`imagemagick-<ver>-<os>-<arch>-no-openmp.tar.gz\` — ImageMagick built with \`--disable-openmp\`, for hosts running many ImageMagick processes concurrently (e.g. web/worker fleets)
+
           ### Install
 
           \`\`\`bash
@@ -186,6 +204,12 @@ jobs:
 
           \`\`\`bash
           curl -fsSL https://raw.githubusercontent.com/jksy/imagemagick-build/main/install.sh | bash
+          \`\`\`
+
+          no-openmp variant をインストールする場合 / To install the no-openmp variant:
+
+          \`\`\`bash
+          curl -fsSL https://raw.githubusercontent.com/jksy/imagemagick-build/main/install.sh | IMAGEMAGICK_VARIANT=no-openmp bash
           \`\`\`
           BODYEOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: bash scripts/sync-readme.sh --check
 
   build-and-test:
-    name: Build and Test ImageMagick (${{ matrix.os_tag }}-${{ matrix.arch }})
+    name: Build and Test ImageMagick (${{ matrix.os_tag }}-${{ matrix.arch }}${{ matrix.variant && format(', {0}', matrix.variant) || '' }})
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container || '' }}
     strategy:
@@ -57,6 +57,13 @@ jobs:
             container: amazonlinux:2023
             os_tag: amzn2023
             arch: aarch64
+          # The no-openmp variant is exercised on a single platform to keep
+          # PR CI cost reasonable; release builds (build.yml) cover every
+          # platform in both variants.
+          - runner: ubuntu-24.04
+            os_tag: ubuntu24.04
+            arch: x86_64
+            variant: no-openmp
 
     steps:
       - name: Install tar and git (AL2023 minimal container)
@@ -70,3 +77,4 @@ jobs:
         uses: ./.github/actions/build-imagemagick
         with:
           cache_suffix: ${{ matrix.os_tag }}-${{ matrix.arch }}
+          disable_openmp: ${{ matrix.variant == 'no-openmp' && 'true' || 'false' }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ curl -fsSL https://raw.githubusercontent.com/jksy/imagemagick-build/main/install
 curl -fsSL https://raw.githubusercontent.com/jksy/imagemagick-build/main/install.sh | IMAGEMAGICK_INSTALL_BASE=$HOME/.local bash
 ```
 
+## Variants / ビルドバリアント
+
+Each release ships every platform in two variants:
+
+| Variant | Asset name | Description |
+|---|---|---|
+| default | `imagemagick-<ver>-<os>-<arch>.tar.gz` | Standard build, OpenMP enabled |
+| no-openmp | `imagemagick-<ver>-<os>-<arch>-no-openmp.tar.gz` | ImageMagick configured with `--disable-openmp`. For hosts running many ImageMagick processes concurrently (web/worker fleets), where OpenMP threads oversubscribe the CPU and hurt latency. Delegate libraries are identical to the default variant. |
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jksy/imagemagick-build/main/install.sh | IMAGEMAGICK_VARIANT=no-openmp bash
+```
+
+> Both variants unpack to the same `imagemagick/<version>/` directory — install only one variant per `IMAGEMAGICK_INSTALL_BASE`.
+>
+> 各リリースには全プラットフォーム × 2 バリアント（default / no-openmp）のアーカイブが含まれます。no-openmp は ImageMagick を `--disable-openmp` でビルドしたもので、多数の ImageMagick プロセスを並行実行するホスト（Web/ワーカー系）向けです。両バリアントは同じ `imagemagick/<version>/` に展開されるため、1 つのインストール先にはどちらか一方のみをインストールしてください。
+
 ## Usage: Download Pre-built Binary
 
 > **For GitHub Actions users:** [jksy/setup-imagemagick](https://github.com/jksy/setup-imagemagick) provides a ready-to-use action that downloads and sets up ImageMagick from these releases automatically.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,9 +28,10 @@ rebuild-on-library-update.yml（main への push を検知）
 
 ↓ build.yml（v* タグで起動）
 
-  build ジョブ: 6プラットフォーム並列ビルド
+  build ジョブ: 6プラットフォーム × 2バリアント = 12並列ビルド
     Ubuntu 22.04 / 24.04 × x86_64 / aarch64
     Amazon Linux 2023  × x86_64 / aarch64
+    バリアント: default（OpenMP有効） / no-openmp（--disable-openmp）
 
   release ジョブ: GitHub Release を作成（tar.gz + SBOM）
 

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,19 @@ case "$ARCH" in
   *) echo "Error: Unsupported architecture: $ARCH" >&2; exit 1 ;;
 esac
 
-echo "Detected: ${PRETTY_NAME:-${ID} ${VERSION_ID}} / ${ARCH}"
+# Variant selection. IMAGEMAGICK_VARIANT=no-openmp installs the build where
+# ImageMagick was configured with --disable-openmp (for hosts running many
+# ImageMagick processes concurrently). Empty or "default" selects the
+# standard OpenMP-enabled build. Note: both variants unpack to the same
+# imagemagick/<version>/ directory, so install only one per INSTALL_BASE.
+VARIANT="${IMAGEMAGICK_VARIANT:-}"
+case "${VARIANT}" in
+  ""|default) VARIANT_SUFFIX="" ;;
+  no-openmp)  VARIANT_SUFFIX="-no-openmp" ;;
+  *) echo "Error: Unsupported IMAGEMAGICK_VARIANT: ${VARIANT} (supported: no-openmp)" >&2; exit 1 ;;
+esac
+
+echo "Detected: ${PRETTY_NAME:-${ID} ${VERSION_ID}} / ${ARCH}${VARIANT_SUFFIX:+ / variant: ${VARIANT}}"
 
 # Ensure required tools and runtime dependencies are available
 _missing=()
@@ -81,24 +93,29 @@ else
 fi
 unset _curl_auth
 echo "::endgroup::"
+# "|| true" keeps set -e from killing the script when grep finds no match,
+# so the explicit empty-check below can print a useful error instead.
 ASSET_URL=$(echo "$RELEASE_JSON" \
   | grep '"browser_download_url"' \
   | cut -d'"' -f4 \
-  | grep -E "${OS_TAG}-${ARCH}\.tar\.gz$")
+  | grep -E "${OS_TAG}-${ARCH}${VARIANT_SUFFIX}\.tar\.gz$" || true)
 
 if [[ "$(echo "$ASSET_URL" | wc -l)" -gt 1 ]]; then
-  echo "Error: Multiple matching tarball assets found for ${OS_TAG} ${ARCH}" >&2
+  echo "Error: Multiple matching tarball assets found for ${OS_TAG} ${ARCH}${VARIANT_SUFFIX}" >&2
   echo "$ASSET_URL" >&2
   exit 1
 fi
 
 if [[ -z "$ASSET_URL" ]]; then
-  echo "Error: No matching asset found for ${OS_TAG} ${ARCH}" >&2
+  echo "Error: No matching asset found for ${OS_TAG} ${ARCH}${VARIANT_SUFFIX}" >&2
+  if [[ -n "${VARIANT_SUFFIX}" ]]; then
+    echo "Note: the ${VARIANT} variant is only published for releases built after it was introduced." >&2
+  fi
   exit 1
 fi
 
 TARBALL=$(basename "$ASSET_URL")
-IM_VERSION=$(echo "$TARBALL" | sed "s/^imagemagick-//" | sed "s/-${OS_TAG}-${ARCH}\.tar\.gz$//")
+IM_VERSION=$(echo "$TARBALL" | sed "s/^imagemagick-//" | sed "s/-${OS_TAG}-${ARCH}${VARIANT_SUFFIX}\.tar\.gz$//")
 
 echo "Installing ImageMagick ${IM_VERSION}..."
 echo "  Source:      ${ASSET_URL}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,6 +32,7 @@ echo "  libaom      : ${AOM_VERSION}"
 echo "  libde265    : ${DE265_VERSION}"
 echo "  libheif     : ${HEIF_VERSION}"
 echo "  LibRaw      : ${RAW_VERSION}"
+echo "  OpenMP      : $([ "${DISABLE_OPENMP:-0}" = "1" ] && echo "disabled (no-openmp variant)" || echo "enabled")"
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -39,6 +40,14 @@ echo "  LibRaw      : ${RAW_VERSION}"
 PREFIX="${PREFIX:-/opt/imagemagick}"
 BUILD_DIR="${BUILD_DIR:-/tmp/imagemagick-build}"
 NPROC=$(nproc 2>/dev/null || echo 4)
+
+# DISABLE_OPENMP=1 builds ImageMagick itself with --disable-openmp (the
+# "no-openmp" variant). Delegate libraries are built identically in both
+# variants: only ImageMagick's own thread pool is affected. This variant
+# exists for hosts that run many ImageMagick processes concurrently (e.g.
+# web/worker fleets), where OpenMP threads oversubscribe the CPU and hurt
+# latency.
+DISABLE_OPENMP="${DISABLE_OPENMP:-0}"
 
 export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 export LD_LIBRARY_PATH="${PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
@@ -230,6 +239,10 @@ echo "::group::Building ImageMagick ${IM_VERSION}"
 clone_or_update https://github.com/ImageMagick/ImageMagick.git \
   imagemagick "${IM_VERSION}"
 cd imagemagick
+IM_EXTRA_FLAGS=()
+if [ "${DISABLE_OPENMP}" = "1" ]; then
+  IM_EXTRA_FLAGS+=(--disable-openmp)
+fi
 ./configure \
   --prefix="${PREFIX}" \
   --with-heic=yes \
@@ -244,6 +257,7 @@ cd imagemagick
   --disable-static \
   --without-perl \
   --without-python \
+  "${IM_EXTRA_FLAGS[@]}" \
   PKG_CONFIG_PATH="${PKG_CONFIG_PATH}"
 make -j"${NPROC}"
 make install

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -11,7 +11,16 @@ IM_VERSION=$(jq -r '.[] | select(.key == "imagemagick") | .version' "${LIBRARIES
 OS_TAG="${OS_TAG:-ubuntu22.04}"
 ARCH="${ARCH:-$(uname -m)}"
 
-ARCHIVE_NAME="imagemagick-${IM_VERSION}-${OS_TAG}-${ARCH}.tar.gz"
+# VARIANT names an alternate build flavor (e.g. "no-openmp") and becomes an
+# archive name suffix so variants can coexist as release assets. Empty or
+# "default" means the standard build with no suffix.
+VARIANT="${VARIANT:-}"
+case "${VARIANT}" in
+  ""|default) VARIANT_SUFFIX="" ;;
+  *) VARIANT_SUFFIX="-${VARIANT}" ;;
+esac
+
+ARCHIVE_NAME="imagemagick-${IM_VERSION}-${OS_TAG}-${ARCH}${VARIANT_SUFFIX}.tar.gz"
 ARCHIVE_PATH="${ARCHIVE_DIR:-/tmp}/${ARCHIVE_NAME}"
 
 echo "=== Packaging ImageMagick ${IM_VERSION} ==="

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -57,6 +57,29 @@ else
 fi
 echo "::endgroup::"
 
+# OpenMP feature — the Features line of "-version" lists OpenMP only when
+# ImageMagick was compiled with it. DISABLE_OPENMP=1 (the no-openmp variant)
+# must not list it; the default variant must. Asserting both directions
+# guards against a variant mix-up in packaging.
+echo ""
+echo "::group::OpenMP feature"
+FEATURES_LINE=$("${MAGICK}" -version | grep -iE '^Features' || true)
+echo "  ${FEATURES_LINE:-Features line not found}"
+if [ "${DISABLE_OPENMP:-0}" = "1" ]; then
+  if echo "${FEATURES_LINE}" | grep -qw OpenMP; then
+    echo "  [ERROR] OpenMP is enabled but this is the no-openmp variant" >&2
+    exit 1
+  fi
+  echo "  [OK] OpenMP disabled (no-openmp variant)"
+else
+  if ! echo "${FEATURES_LINE}" | grep -qw OpenMP; then
+    echo "  [ERROR] OpenMP feature missing from default variant build" >&2
+    exit 1
+  fi
+  echo "  [OK] OpenMP enabled"
+fi
+echo "::endgroup::"
+
 # pkg-config
 echo ""
 echo "::group::pkg-config"


### PR DESCRIPTION
## 概要

各プラットフォームについて、ImageMagick 本体を `--disable-openmp` でビルドした **no-openmp variant** のアセットを追加公開します。

## 変更内容

| ファイル | 変更 |
|---|---|
| `scripts/build.sh` | `DISABLE_OPENMP=1` で ImageMagick の configure に `--disable-openmp` を追加(デリゲートは両 variant で同一) |
| `scripts/verify.sh` | `magick -version` の Features 行を variant と突き合わせて双方向にアサート(パッケージ取り違え検知) |
| `scripts/package.sh` | `VARIANT` 環境変数でアセット名に `-no-openmp` サフィックスを付与 |
| `.github/actions/build-imagemagick` | `disable_openmp` 入力を追加。variant をキャッシュキーに組み込み(v3→v4)、variant 間のキャッシュ混線を構造的に防止。失敗時テストログの artifact 名衝突も解消 |
| `.github/workflows/build.yml` | マトリクスを variant × target の2軸に(6→12ジョブ)。リリースノートに variant の説明とインストール手順を追加 |
| `.github/workflows/ci.yml` | PR CI で no-openmp variant を 1 プラットフォーム(ubuntu24.04-x86_64)だけビルド検証 |
| `install.sh` | `IMAGEMAGICK_VARIANT=no-openmp` で variant を選択可能に。アセット不一致時に `set -e` でエラーメッセージ到達前に落ちる既存バグも修正 |
| `README.md` / `RELEASE.md` | variant のドキュメント追加 |

## アセット命名

- `imagemagick-<ver>-<os>-<arch>.tar.gz` — 従来どおり(後方互換)
- `imagemagick-<ver>-<os>-<arch>-no-openmp.tar.gz` — 新規

両 variant は同じ `imagemagick/<version>/` に展開されるため、1 インストール先につきどちらか一方のみ使用します。

## テスト

- `shellcheck` / `actionlint` / `sync-readme.sh --check` パス(shellcheck の SC2086 は未変更の generate-sbom.sh の既存警告)
- `package.sh`: VARIANT 空 / `default` / `no-openmp` で命名を確認
- `install.sh`: 実リリース(v7.1.2-26)に対して default インストールが従来どおり成功、`IMAGEMAGICK_VARIANT=no-openmp` は未公開アセットの案内付きエラー、不正値はバリデーションエラーになることを確認
- `verify.sh`: 実バイナリ(OpenMP 入り)に対し default モードでフルパス、`DISABLE_OPENMP=1` では OpenMP チェックで正しく失敗することを確認
- `--disable-openmp` ビルド自体は CI の新ジョブ(no-openmp)で検証されます

## マージ後

- 次のタグビルドから no-openmp アセットが公開されます
- 公開後、`test-installer.yml` に `IMAGEMAGICK_VARIANT=no-openmp` のテストジョブを追加予定(現時点では既存リリースにアセットが無く CI が赤になるため見送り)

🤖 Generated with [Claude Code](https://claude.com/claude-code)