### PR TITLE
chore: bump ImageMagick to 7.1.2-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ JPEG, PNG, TIFF, WebP, AVIF, HEIC (read), PDF, RAW (read: DNG, CR2/CR3, NEF, ARW
 <!-- BUNDLED_LIBRARIES_START -->
 | Library | Version |
 |---|---|
-| ImageMagick | 7.1.2-26 |
+| ImageMagick | 7.1.2-27 |
 | libjpeg-turbo | 3.2.0 |
 | libpng | 1.6.58 |
 | libtiff | 4.7.2 |

--- a/libraries.json
+++ b/libraries.json
@@ -2,7 +2,7 @@
   {
     "key": "imagemagick",
     "name": "ImageMagick",
-    "version": "7.1.2-26",
+    "version": "7.1.2-27",
     "purl_base": "pkg:github/ImageMagick/ImageMagick",
     "bundled": true,
     "repo": "https://github.com/ImageMagick/ImageMagick.git"


### PR DESCRIPTION
ImageMagick 7.1.2-27 が公開されたため、自動バージョンアップします。